### PR TITLE
Optimize Issue graphql calls

### DIFF
--- a/graphql/queries/fetch-issues-and-pr.graphql
+++ b/graphql/queries/fetch-issues-and-pr.graphql
@@ -1,6 +1,13 @@
-query FetchIssuesAndPr($owner: String!, $name: String!, $filter: IssueFilters, $cursor: String, $commentCursor: String) {
+query FetchIssuesAndPr(
+  $owner: String!
+  $name: String!
+  $filter: IssueFilters
+  $issueCursor: String
+  $prCursor: String
+  $commentCursor: String
+) {
   repository(owner: $owner, name: $name) {
-    issues(first: 100, filterBy: $filter, after: $cursor) {
+    issues(first: 100, filterBy: $filter, after: $issueCursor) {
       edges {
         cursor
         node {
@@ -30,7 +37,7 @@ query FetchIssuesAndPr($owner: String!, $name: String!, $filter: IssueFilters, $
         }
       }
     }
-    pullRequests(first: 100, after: $cursor) {
+    pullRequests(first: 100, after: $prCursor) {
       edges {
         cursor
         node {

--- a/graphql/queries/fetch-issues.graphql
+++ b/graphql/queries/fetch-issues.graphql
@@ -1,4 +1,4 @@
-query FetchIssues($owner: String!, $name: String!, $filter: IssueFilters, $cursor: String, $commentCursor: String) {
+query FetchIssues($owner: String!, $name: String!, $filter: IssueFilters, $cursor: String) {
   repository(owner: $owner, name: $name) {
     issues(first: 100, filterBy: $filter, after: $cursor) {
       edges {
@@ -16,14 +16,6 @@ query FetchIssues($owner: String!, $name: String!, $filter: IssueFilters, $curso
             edges {
               node {
                 ...issueAssignee
-              }
-            }
-          }
-          comments(first: 100, after: $commentCursor) {
-            edges {
-              cursor
-              node {
-                ...issueComment
               }
             }
           }

--- a/graphql/queries/fetch-pullrequests.graphql
+++ b/graphql/queries/fetch-pullrequests.graphql
@@ -1,4 +1,4 @@
-query FetchPullRequests($owner: String!, $name: String!, $cursor: String, $commentCursor: String) {
+query FetchPullRequests($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequests(first: 100, after: $cursor) {
       edges {
@@ -16,14 +16,6 @@ query FetchPullRequests($owner: String!, $name: String!, $cursor: String, $comme
             edges {
               node {
                 ...issueAssignee
-              }
-            }
-          }
-          comments(first: 100, after: $commentCursor) {
-            edges {
-              cursor
-              node {
-                ...issueComment
               }
             }
           }

--- a/graphql/queries/fetch-pullrequests.graphql
+++ b/graphql/queries/fetch-pullrequests.graphql
@@ -1,0 +1,34 @@
+query FetchPullRequests($owner: String!, $name: String!, $cursor: String, $commentCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: 100, after: $cursor) {
+      edges {
+        cursor
+        node {
+          ...pullrequest
+          labels(first: 100) {
+            edges {
+              node {
+                ...issueLabel
+              }
+            }
+          }
+          assignees(first: 100) {
+            edges {
+              node {
+                ...issueAssignee
+              }
+            }
+          }
+          comments(first: 100, after: $commentCursor) {
+            edges {
+              cursor
+              node {
+                ...issueComment
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -100,6 +100,9 @@ export class AppModule {
       return forward(operation).map((result) => {
         const time = performance.now() - operation.getContext().start;
         this.logger.info('response', operation.getContext(), `in ${Math.round(time)}ms`);
+        const repo = operation.getContext().response.body.data.repository;
+        const item = Object.keys(repo)[0];
+        this.logger.debug('response body', item, repo[item].edges.length, repo[item].edges);
         return result;
       });
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -92,14 +92,14 @@ import { SharedModule } from './shared/shared.module';
   entryComponents: [UserConfirmationComponent, SessionFixConfirmationComponent, LabelDefinitionPopupComponent]
 })
 export class AppModule {
-  constructor(private apollo: Apollo, private httpLink: HttpLink, private authService: AuthService) {
+  constructor(private apollo: Apollo, private httpLink: HttpLink, private authService: AuthService, private logger: LoggingService) {
     const URI = 'https://api.github.com/graphql';
     const log = new ApolloLink((operation, forward) => {
       operation.setContext({ start: performance.now() });
-      console.info('request', operation.getContext());
+      this.logger.info('request', operation.getContext());
       return forward(operation).map((result) => {
         const time = performance.now() - operation.getContext().start;
-        console.info('response', operation.getContext(), `in ${Math.round(time)}ms`);
+        this.logger.info('response', operation.getContext(), `in ${Math.round(time)}ms`);
         return result;
       });
     });

--- a/src/app/core/models/github/github-graphql.issue-or-pr.ts
+++ b/src/app/core/models/github/github-graphql.issue-or-pr.ts
@@ -20,11 +20,7 @@ export class GithubGraphqlIssueOrPr extends GithubIssue {
         avatar_url: issue.author.avatarUrl
       },
       assignees: flattenEdges(issue.assignees.edges),
-      labels: flattenEdges(issue.labels.edges),
-      comments: flattenEdges(issue.comments.edges, (node) => ({
-        ...node,
-        id: node.databaseId
-      }))
+      labels: flattenEdges(issue.labels.edges)
     });
   }
 }

--- a/src/app/core/models/github/github-issue.model.ts
+++ b/src/app/core/models/github/github-issue.model.ts
@@ -24,7 +24,7 @@ export class GithubIssue {
     avatar_url: string;
     url: string;
   };
-  comments: Array<GithubComment>;
+  comments?: Array<GithubComment>;
   issueOrPr?: string;
 
   constructor(githubIssue: {}) {


### PR DESCRIPTION
### Summary:
Fix #15.

### Changes Made:
- Add logging for Graphql queries
- Separate Graphql queries for Issues and Pull requests to prevent overlapping cursor-pagination.
- Stop fetching comments in Graphql queries

### Commit Message:

```
Graphql queries fetch the same items repeatedly.

Let's prevent redundant fetching by separating Graphql queries
for issues and pull requests.
```
