### PR TITLE
Issue Dashboard: Switch repository feature after logged in

### DIFF
--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -61,7 +61,7 @@ export class ConfirmLoginComponent implements OnInit {
    */
   completeLoginProcess(): void {
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
-    const currentRepo: Repo = { owner: window.localStorage.getItem('org'), name: window.localStorage.getItem('dataRepo') };
+    const currentRepo = new Repo(window.localStorage.getItem('org'), window.localStorage.getItem('dataRepo'));
     const sessionData: SessionData = {
       sessionRepo: [
         { phase: Phase.issuesViewer, repos: [currentRepo] }

--- a/src/app/core/models/repo.model.ts
+++ b/src/app/core/models/repo.model.ts
@@ -1,4 +1,21 @@
-export interface Repo {
+export class Repo {
   owner: string;
   name: string;
+
+  constructor(owner: string, name: string) {
+    this.owner = owner;
+    this.name = name;
+  }
+
+  public static of(repoUrl: string) {
+    const repoUrlSplit = repoUrl.split('/');
+    if (repoUrlSplit.length != 2) {
+      return undefined; // throw error?
+    }
+    return new Repo(repoUrlSplit[0], repoUrlSplit[1]);
+  }
+
+  public toString(): string {
+    return this.owner + '/' + this.name;
+  }
 }

--- a/src/app/core/models/repo.model.ts
+++ b/src/app/core/models/repo.model.ts
@@ -9,7 +9,7 @@ export class Repo {
 
   public static of(repoUrl: string) {
     const repoUrlSplit = repoUrl.split('/');
-    if (repoUrlSplit.length != 2) {
+    if (repoUrlSplit.length !== 2) {
       return undefined; // throw error?
     }
     return new Repo(repoUrlSplit[0], repoUrlSplit[1]);

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -67,6 +67,17 @@ export class PhaseService {
   }
 
   /**
+   * Sets new current repository
+   */
+  setCurrentRepository(repo: Repo): void {
+    this.otherRepos.push(this.currentRepo); // Future TODO: history of previous repos
+    this.currentRepo = repo;
+    this.sessionData.sessionRepo.filter((x) => x.phase === this.currentPhase)[0].repos = this.getRepository();
+    localStorage.setItem('sessionData', JSON.stringify(this.sessionData));
+    this.updateSessionParameters(this.sessionData);
+  }
+
+  /**
    * Retrieves session data from local storage and update phase service with it.
    */
   setSessionData() {

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -26,3 +26,11 @@ app-label-chip-bar {
 .label-filter-grid-tile {
   overflow: auto;
 }
+
+.submit-button {
+  margin-left: 8px;
+}
+
+.switch-repo-tile {
+  background-color: lightblue;
+}

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -1,3 +1,18 @@
+<mat-card>
+  <form [formGroup]="repoForm" (ngSubmit)="switchRepo()">
+    <mat-card-content>
+      <mat-form-field class="login-field">
+        <input matInput placeholder="Repository Location (Org/Repo)" formControlName="repoInput" required />
+      </mat-form-field>
+      <mat-card-actions>
+        <button type="submit" mat-stroked-button color="primary">
+          <div>Submit</div>
+        </button>
+      </mat-card-actions>
+    </mat-card-content>
+  </form>
+</mat-card>
+
 <div>
   <mat-grid-list cols="8" rowHeight="80px">
     <mat-grid-tile colspan="2">

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -1,20 +1,16 @@
-<mat-card>
-  <form [formGroup]="repoForm" (ngSubmit)="switchRepo()">
-    <mat-card-content>
-      <mat-form-field class="login-field">
-        <input matInput placeholder="Repository Location (Org/Repo)" formControlName="repoInput" required />
-      </mat-form-field>
-      <mat-card-actions>
-        <button type="submit" mat-stroked-button color="primary">
+<div>
+  <mat-grid-list cols="9" rowHeight="80px">
+    <mat-grid-tile colspan="2" class="switch-repo-tile">
+      <form [formGroup]="repoForm" (ngSubmit)="switchRepo()">
+        <mat-form-field class="login-field">
+          <input matInput placeholder="Repository Location (Org/Repo)" formControlName="repoInput" required />
+        </mat-form-field>
+        <button class="submit-button" type="submit" mat-stroked-button color="primary">
           <div>Submit</div>
         </button>
-      </mat-card-actions>
-    </mat-card-content>
-  </form>
-</mat-card>
+      </form>
+    </mat-grid-tile>
 
-<div>
-  <mat-grid-list cols="8" rowHeight="80px">
     <mat-grid-tile colspan="2">
       <mat-form-field class="search-bar">
         <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
@@ -64,7 +60,7 @@
       </div>
     </mat-grid-tile>
 
-    <mat-grid-tile class="label-filter-grid-tile" colspan="3">
+    <mat-grid-tile class="label-filter-grid-tile" colspan="2">
       <app-label-chip-bar [selectedLabels]="this.labelFilter$"></app-label-chip-bar>
     </mat-grid-tile>
   </mat-grid-list>

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -1,10 +1,13 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSort } from '@angular/material';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { GithubUser } from '../core/models/github-user.model';
+import { Repo } from '../core/models/repo.model';
 import { GithubService } from '../core/services/github.service';
 import { LoggingService } from '../core/services/logging.service';
 import { MilestoneService } from '../core/services/milestone.service';
+import { PhaseService } from '../core/services/phase.service';
 import { TABLE_COLUMNS } from '../shared/issue-tables/issue-tables-columns';
 import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../shared/issue-tables/IssuesDataTable';
 import { CardViewComponent } from './card-view/card-view.component';
@@ -25,9 +28,19 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChildren(CardViewComponent) cardViews: QueryList<CardViewComponent>;
   @ViewChild(MatSort, { static: true }) matSort: MatSort;
 
-  constructor(public githubService: GithubService, private milestoneService: MilestoneService, private logger: LoggingService) {}
+  repoForm = new FormGroup({
+    repoInput: new FormControl(['', Validators.required])
+  });
+
+  constructor(
+    public phaseService: PhaseService,
+    public githubService: GithubService,
+    private milestoneService: MilestoneService,
+    private logger: LoggingService
+  ) {}
 
   ngOnInit() {
+    this.repoForm.setValue({ repoInput: this.phaseService.currentRepo.toString() });
     this.githubService.getUsersAssignable().subscribe((x) => (this.assignees = x));
     this.milestoneService.fetchMilestones().subscribe(
       (response) => {
@@ -55,5 +68,9 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   applyDropdownFilter() {
     this.cardViews.forEach((v) => (v.issues.dropdownFilter = this.dropdownFilter));
+  }
+
+  switchRepo() {
+    this.phaseService.setCurrentRepository(Repo.of(this.repoForm.controls['repoInput'].value));
   }
 }

--- a/src/app/issues-viewer/label-chip-bar/label-chip-bar.component.ts
+++ b/src/app/issues-viewer/label-chip-bar/label-chip-bar.component.ts
@@ -34,6 +34,10 @@ export class LabelChipBarComponent implements OnInit {
   constructor(private labelService: LabelService, private logger: LoggingService) {}
 
   ngOnInit(): void {
+    this.load();
+  }
+
+  public load() {
     this.labelService.fetchLabels().subscribe(
       (response) => {
         this.logger.debug('Fetched labels from Github');


### PR DESCRIPTION
### Summary:
Addresses 2nd point of https://github.com/CATcher-org/WATcher/issues/22#issuecomment-1193159356

### Changes Made:
- Switch repository after login
- Convert card to span to save space
- Lightblue background to distinguish from filters and search bar
- Future: Convert to a dialog

### Commit Message:

```
Let's implement feature to switch repository after login.
```

<img width="928" alt="image" src="https://user-images.githubusercontent.com/77230723/181499992-d83bdf33-5c13-477a-aa78-4f2a2688f29c.png">
