### PR TITLE
Specify geojson version in package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@angular/router": "^8.2.14",
     "@octokit/rest": "^16.37.0",
     "@primer/octicons": "^17.3.0",
+    "@types/geojson": "7946.0.8",
     "ajv": "^6.11.0",
     "apollo-angular": "^1.9.1",
     "apollo-angular-link-http": "^1.10.0",


### PR DESCRIPTION
### Summary:
Fixes #48 

### Changes Made:
- Add "@types/geojson": "7946.0.8" to dependencies in package.json

### Commit Message:

```
Let's fix the error thrown when running npm start
due to geojson.
```
