### PR TITLE
Change count to show the total number of filtered issues or PRs

### DIFF
--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -108,7 +108,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     // Fetch labels
     this.labelChipBar.load();
 
-    // FEtch milestones
+    // Fetch milestones
     this.milestoneService.fetchMilestones().subscribe(
       (response) => {
         this.logger.debug('Fetched milestones from Github');

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -139,12 +139,11 @@ export class IssuesDataTable extends DataSource<Issue> {
               }
               data = this.getFilteredTeamData(data);
               data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
+              this.count = data.length;
+
               if (this.paginator !== undefined) {
                 data = paginateData(this.paginator, data);
               }
-
-              this.count = data.length;
-
               return data;
             })
           );


### PR DESCRIPTION
### Summary:
Fixes #42

### Changes Made:
- Change IssuesDataTable to update count to the total number of filtered issues or PRs instead of the number in the page.

### Commit Message:

```
Let's change the count to show the total number of
filtered issues or PRs in the card view.
```
