### PR TITLE
Fix Referenced error

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -60,3 +60,4 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+(window as any).global = window;


### PR DESCRIPTION
### Summary:
Fixes #53, #54

### Changes Made:

- Included a line in ```polyfills.ts``` to manually shim ```global``` for running in browser environment 

### Commit Message:

```
Fix Referenced error 

Angular does not support a shim for global while some libraries assume 
globals are present. 

Let's manually shim it inside polyfills.ts
```
