### PR TITLE
Reset milestone selection upon repo change

### DIFF
--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -51,7 +51,7 @@
         </mat-form-field>
         <mat-form-field appearance="standard">
           <mat-label>Milestone</mat-label>
-          <mat-select [(value)]="this.dropdownFilter.milestones" (selectionChange)="applyDropdownFilter()" multiple>
+          <mat-select #milestoneSelectorRef [(value)]="this.dropdownFilter.milestones" (selectionChange)="applyDropdownFilter()" multiple>
             <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.number">{{
               milestone.title
             }}</mat-option>

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatSort } from '@angular/material';
+import { MatOption, MatSelect, MatSort } from '@angular/material';
+import { MatSelectSearchClearDirective } from 'ngx-mat-select-search/mat-select-search-clear.directive';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { GithubUser } from '../core/models/github-user.model';
 import { Repo } from '../core/models/repo.model';
@@ -38,6 +39,9 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(MatSort, { static: true }) matSort: MatSort;
 
   @ViewChild(LabelChipBarComponent, { static: true }) labelChipBar: LabelChipBarComponent;
+
+  @ViewChild('milestoneSelectorRef', {static: false}) milestoneSelectorRef: MatSelect;
+
 
   /** Switch repository form */
   repoForm = new FormGroup({
@@ -112,6 +116,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.milestoneService.fetchMilestones().subscribe(
       (response) => {
         this.logger.debug('Fetched milestones from Github');
+        this.milestoneSelectorRef.options.forEach((data: MatOption) => data.deselect());
       },
       (err) => {},
       () => {}


### PR DESCRIPTION
### Summary:
Fixes #46 

### Changes Made:
- Reset milestone selection upon repo change

### Commit Message:

```
Previously, milestones selected in the milestone filter are not cleared 
upon a repository change. This means that old milestones from the 
previous repository remain selected, which may or may not exist in the 
newly loaded repository. As such, the milestone selection should be 
fresh and reset for every new repo loaded.

Let's reset the milestone selection upon a repository change 
```
