### PR TITLE
Fix hard to see text labels

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -75,24 +75,19 @@ export class LabelService {
   }
 
   /**
-   * Returns a css style for the label to use
+   * Returns a css style for the background and text color of the label
    * @param color: the color of the label
    * @return the style with background-color in rgb
    * @throws exception if input is an invalid color code
    */
-  setLabelStyle(color: string, display: string = 'inline-flex') {
+  setLabelStyle(color: string) {
     let textColor: string;
 
     textColor = this.isDarkColor(color) ? COLOR_WHITE : COLOR_BLACK;
 
     const styles = {
       'background-color': `#${color}`,
-      'border-radius': '3px',
-      cursor: 'default',
-      padding: '3px',
-      color: `#${textColor}`,
-      'font-weight': '410',
-      display: display
+      color: `#${textColor}`
     };
 
     return styles;

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -33,7 +33,7 @@
           </mat-card-header>
           <mat-card-content>
             <mat-chip-list aria-label="Labels">
-              <mat-chip *ngFor="let label of issue.githubLabels" [ngStyle]="{ 'background-color': '#' + label.color }" selected>
+              <mat-chip *ngFor="let label of issue.githubLabels" [ngStyle]="labelService.setLabelStyle(label.color)" selected>
                 {{ label.name }}
               </mat-chip>
             </mat-chip-list>

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -7,6 +7,7 @@ import { GithubService } from '../../core/services/github.service';
 import { IssueService } from '../../core/services/issue.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { IssuesDataTable } from '../../shared/issue-tables/IssuesDataTable';
+import { LabelService } from '../../core/services/label.service';
 
 @Component({
   selector: 'app-card-view',
@@ -28,7 +29,12 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy {
   issues: IssuesDataTable;
   issues$: Observable<Issue[]>;
 
-  constructor(private githubService: GithubService, public issueService: IssueService, private loggingService: LoggingService) {}
+  constructor(
+    private githubService: GithubService,
+    public issueService: IssueService,
+    public labelService: LabelService,
+    private loggingService: LoggingService
+  ) {}
 
   ngOnInit() {
     this.issues = new IssuesDataTable(this.issueService, this.sort, this.paginator, this.headers, this.assignee, this.filters);


### PR DESCRIPTION
### Summary:

Closes #63 

### Changes Made:
Applies `setLabelStyle()` from LabelService to the displayed labels to fix the lack of contrast for labels with a light background color
-

### Commit Message:

```
Fix missing dynamic label text color

The method to determine if a label's font color should be 
black or white is already present in the codebase but is not applied.
This caused some labels text to be hard to see due to the lack of contrast. 
This fixes the issue by applying the style settings to the labels.
```
