### PR TITLE
Fix uncaught httpError arising from promise

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -590,9 +590,16 @@ export class GithubService {
       headers: { 'If-None-Match': this.issuesCacheManager.getEtagFor(pageNumber) },
       state: 'all'
     });
-    const apiCall$ = from(apiCall);
+    const apiCall$ = from(apiCall.catch(
+      err => {
+        return this.issuesCacheManager.get(pageNumber);
+      }
+    ));
+
     return apiCall$.pipe(
       catchError((err) => {
+        //catchError does not appear to catch an error on an observable created from a promise...
+        this.logger.info(`GithubService: Error caught in getIssuesAPICall`)
         return of(this.issuesCacheManager.get(pageNumber));
       })
     );


### PR DESCRIPTION
### Summary:
Fixes #41 

See discussion in #41 for more info

### Commit Message:

```
Fix uncaught httpError arising from promise

`catchError` does not appear to catch an error on an observable created 
from a promise.

Let's catch the error in the promise before converting it to an 
observable.
```
