### PR TITLE
Clear Issues before fetching and populating IssuesDataTable

### DIFF
--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -104,6 +104,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.githubService.getUsersAssignable().subscribe((x) => (this.assignees = x));
 
     // Fetch issues
+    this.issueService.reset(false);
     this.issueService.reloadAllIssues();
 
     // Fetch labels


### PR DESCRIPTION
### Summary:
Fixes #100.

Currently, WATcher does not clear its entire store of Issues before fetching and repopulating the IssuesDataTable. This results in the persistence of issues between switches of repos. This is a problem as if the 2 repos have the common members, Issues by that member continue to persist until the issues have been completely fetched and repopulated. Instead, let's reset the issues before fetching and populating the table. 

### Changes Made:
- Update `IssuesViewerComponent::initialize` to reset Issues using `issueService::reset` before reloading.

### Commit Message:
```
Reset the `IssuesDataTable` before fetching and repopulating Issues.
```
