### PR TITLE
119 fix datatable inefficiency

### DIFF
--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -2,7 +2,7 @@ import { DataSource } from '@angular/cdk/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { BehaviorSubject, merge, Observable, Subscription } from 'rxjs';
-import { flatMap, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { GithubUser } from '../../core/models/github-user.model';
 import { Issue } from '../../core/models/issue.model';
 import { IssueService } from '../../core/services/issue.service';

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -83,72 +83,67 @@ export class IssuesDataTable extends DataSource<Issue> {
     ].filter((x) => x !== undefined);
 
     this.issueService.startPollIssues();
-    this.issueSubscription = this.issueService.issues$
+    merge(...displayDataChanges)
       .pipe(
-        flatMap(() => {
-          // merge creates an observable from values that changes display
-          return merge(...displayDataChanges).pipe(
-            // maps each change in display value to new issue ordering or filtering
-            map(() => {
-              let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
-              if (this.defaultFilter) {
-                data = data.filter(this.defaultFilter);
+        // maps each change in display value to new issue ordering or filtering
+        map(() => {
+          let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
+          if (this.defaultFilter) {
+            data = data.filter(this.defaultFilter);
+          }
+          // Filter by assignee of issue
+          if (this.assignee) {
+            data = data.filter((issue) => {
+              if (issue.issueOrPr === 'PullRequest') {
+                return issue.author === this.assignee.login;
+              } else if (!issue.assignees) {
+                return false;
+              } else {
+                return issue.assignees.includes(this.assignee.login);
               }
-              // Filter by assignee of issue
-              if (this.assignee) {
-                data = data.filter((issue) => {
-                  if (issue.issueOrPr === 'PullRequest') {
-                    return issue.author === this.assignee.login;
-                  } else if (!issue.assignees) {
-                    return false;
-                  } else {
-                    return issue.assignees.includes(this.assignee.login);
-                  }
-                });
+            });
+          }
+          // Dropdown Filters
+          data = data
+            .filter((issue) => {
+              if (this.dropdownFilter.status === 'open') {
+                return issue.state === 'OPEN';
+              } else if (this.dropdownFilter.status === 'closed') {
+                return issue.state !== 'OPEN';
+              } else {
+                return true;
               }
-              // Dropdown Filters
-              data = data
-                .filter((issue) => {
-                  if (this.dropdownFilter.status === 'open') {
-                    return issue.state === 'OPEN';
-                  } else if (this.dropdownFilter.status === 'closed') {
-                    return issue.state !== 'OPEN';
-                  } else {
-                    return true;
-                  }
-                })
-                .filter((issue) => {
-                  if (this.dropdownFilter.type === 'issue') {
-                    return issue.issueOrPr === 'Issue';
-                  } else if (this.dropdownFilter.type === 'pullrequest') {
-                    return issue.issueOrPr === 'PullRequest';
-                  } else {
-                    return true;
-                  }
-                })
-                .filter((issue) => {
-                  return this.dropdownFilter.labels.every((label) => issue.labels.includes(label));
-                });
-
-              if (Array.isArray(this.dropdownFilter.milestones)) {
-                data = data.filter((issue) => {
-                  return issue.milestone && this.dropdownFilter.milestones.some((milestone) => issue.milestone.number === milestone);
-                });
-              }
-
-              if (this.sort !== undefined) {
-                data = getSortedData(this.sort, data);
-              }
-              data = this.getFilteredTeamData(data);
-              data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
-              this.count = data.length;
-
-              if (this.paginator !== undefined) {
-                data = paginateData(this.paginator, data);
-              }
-              return data;
             })
-          );
+            .filter((issue) => {
+              if (this.dropdownFilter.type === 'issue') {
+                return issue.issueOrPr === 'Issue';
+              } else if (this.dropdownFilter.type === 'pullrequest') {
+                return issue.issueOrPr === 'PullRequest';
+              } else {
+                return true;
+              }
+            })
+            .filter((issue) => {
+              return this.dropdownFilter.labels.every((label) => issue.labels.includes(label));
+            });
+
+          if (Array.isArray(this.dropdownFilter.milestones)) {
+            data = data.filter((issue) => {
+              return issue.milestone && this.dropdownFilter.milestones.some((milestone) => issue.milestone.number === milestone);
+            });
+          }
+
+          if (this.sort !== undefined) {
+            data = getSortedData(this.sort, data);
+          }
+          data = this.getFilteredTeamData(data);
+          data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
+          this.count = data.length;
+
+          if (this.paginator !== undefined) {
+            data = paginateData(this.paginator, data);
+          }
+          return data;
         })
       )
       .subscribe((issues) => {


### PR DESCRIPTION
### Summary:
Currently, a new subscriber is being added to the Observables found in `IssueDataTable` class each time a new issue is being retrieved from `issueService`. This creates at least an n^2 additional runtime which consists of completely unnecessary yet expensive function calls to update the view based on the filter stack. When the method should really be only called once.

### Changes Made:
- Remove unnecessary nesting of subscribers in `IssueDataTable`

### Commit Message:

```
Inefficient nesting of subscribers in IssueDataTable has introduced 
unnecessary and very expensive computes to WATcher.

Let's 
- Improve WATcher's efficiency by removing the nesting of subscribers in IssueDataTable.ts
```
