### PR TITLE
Commited for testing

### DIFF
--- a/src/app/shared/issue-tables/issue-sorter.ts
+++ b/src/app/shared/issue-tables/issue-sorter.ts
@@ -24,7 +24,7 @@ export function getSortedData(sort: MatSort, data: Issue[]): Issue[] {
       case 'id':
         return direction * compareByIntegerValue(a.id, b.id);
       case 'date':
-        return direction * compareByDateValue(a.created_at, b.created_at);
+        return direction * compareByDateValue(a.updated_at, b.updated_at);
       default:
         // title, responseTag are string values
         return direction * compareByStringValue(a[sort.active], b[sort.active]);


### PR DESCRIPTION
### Summary:

Describe the bug
In the issue dashboard, when I try to sort the issues/PRs by date updated, the sequence of cards remain the same as the previous order (sorted by ID), even though some of the issues that have a smaller ID have been more recently updated.

The value used to sort the issues or PRs is incorrect. Let's sort them by using the updated_at attribute in Issue.

### Changes Made:

-yes

### Commit Message:

```
Let's
```
