### PR TITLE
Disable milestone filter if there are no milestones

### DIFF
--- a/src/app/core/services/milestone.service.ts
+++ b/src/app/core/services/milestone.service.ts
@@ -14,6 +14,7 @@ import { GithubService } from './github.service';
  */
 export class MilestoneService {
   milestones: Milestone[];
+  hasNoMilestones: boolean;
 
   constructor(private githubService: GithubService) {}
 
@@ -24,6 +25,7 @@ export class MilestoneService {
     return this.githubService.fetchAllMilestones().pipe(
       map((response) => {
         this.milestones = this.parseMilestoneData(response);
+        this.hasNoMilestones = response.length === 0;
         return response;
       })
     );

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -39,7 +39,16 @@
       </mat-form-field>
       <mat-form-field appearance="standard">
         <mat-label>Milestone</mat-label>
-        <mat-select #milestoneSelectorRef [(value)]="this.dropdownFilter.milestones" (selectionChange)="applyDropdownFilter()" multiple>
+        <mat-select
+          #milestoneSelectorRef
+          [(value)]="this.dropdownFilter.milestones"
+          (selectionChange)="applyDropdownFilter()"
+          [disabled]="this.milestoneService.hasNoMilestones"
+          multiple
+        >
+          <mat-select-trigger *ngIf="this.milestoneService.hasNoMilestones">
+            <span>No Milestones</span>
+          </mat-select-trigger>
           <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.number">
             {{ milestone.title }}
           </mat-option>


### PR DESCRIPTION
### Summary:
Fixes #36

### Changes Made:

- If a repository has no milestones:
  - Disable milestone selector
  - Change the display text to `No Milestones` instead of the existing `Without a milestone`
    - using `mat-select-trigger` with an `*ngIf` to achieve this

![image](https://github.com/CATcher-org/WATcher/assets/47915290/65611bbe-8556-411b-9e05-9f7f4c90de12)

### Commit Message:

```
Disable milestone filter if there are no milestones

Previously, when there are no milestones in a repo, there is still a 
`Milestone.DefaultMilestone` instance in WATcher, with the string 
representation of `Without a milestone` for issues without a milestone. 
This causes the milestone selector to show `Without a milestone` as the 
trigger text when it is selected.

Let's
* Disable the milestone selector
* Set the display text to `No Milestones`
when there are no milestones in a repository.
```
