### PR TITLE
Show loading spinner on switch repository

### DIFF
--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { Phase } from '../models/phase.model';
 import { Repo } from '../models/repo.model';
 import { SessionData } from '../models/session.model';
@@ -51,6 +51,9 @@ export class PhaseService {
    * dependencies subscribe to this observable?
    */
   public repoChanged$: Subject<Repo | null> = new Subject();
+
+  /** Whether the PhaseService is changing the repository */
+  public isChangingRepo = new BehaviorSubject<boolean>(false);
 
   public sessionData = STARTING_SESSION_DATA; // stores session data for the session
 

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -1,14 +1,25 @@
 <div>
-  <app-filter-bar [views$]="views" #filterbar></app-filter-bar>
-
-  <div class="wrapper">
-    <app-card-view
-      *ngFor="let assignee of assignees"
-      class="issue-table"
-      [assignee]="assignee"
-      [headers]="this.displayedColumns"
-      [sort]="filterbar.matSort"
-    ></app-card-view>
-    <app-card-view class="issue-table" [headers]="this.displayedColumns" [sort]="filterbar.matSort"></app-card-view>
+  <div *ngIf="this.phaseService.isChangingRepo | async; else elseBlock;" style="display: flex; justify-content: center; align-items: center">
+    <mat-progress-spinner 
+      color="primary"
+      mode="indeterminate"
+      diameter="50"
+      strokeWidth="5">
+    </mat-progress-spinner>
   </div>
+
+  <ng-template #elseBlock>
+    <app-filter-bar [views$]="views" #filterbar></app-filter-bar>
+
+    <div class="wrapper">
+      <app-card-view
+        *ngFor="let assignee of assignees"
+        class="issue-table"
+        [assignee]="assignee"
+        [headers]="this.displayedColumns"
+        [sort]="filterbar.matSort"
+      ></app-card-view>
+      <app-card-view class="issue-table" [headers]="this.displayedColumns" [sort]="filterbar.matSort"></app-card-view>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -201,13 +201,17 @@ export class HeaderComponent implements OnInit {
   }
 
   changeRepositoryInPhaseIfValid(repo: Repo, newRepoString: string) {
+    this.phaseService.isChangingRepo.next(true);
+
     this.githubService.isRepositoryPresent(repo.owner, repo.name).subscribe((isValidRepository) => {
       if (!isValidRepository) {
+        this.phaseService.isChangingRepo.next(false);
         throw new Error('Invalid repository name. Please check your organisation and repository name.');
       }
 
       this.switchRepo(repo);
       this.currentRepo = newRepoString;
+      this.phaseService.isChangingRepo.next(false);
     });
   }
 


### PR DESCRIPTION
### Summary:
Fixes #35 
WATcher freezes before changing to new repository issues. After some investigation, I believe this delay is due to the checking of the validity of the repository using `isRepositoryPresent` in `changeRepositoryInPhaseIfValid` below:
```
    this.githubService.isRepositoryPresent(repo.owner, repo.name).subscribe((isValidRepository) => {
      if (!isValidRepository) {
        this.phaseService.isChangingRepo.next(false);
        throw new Error('Invalid repository name. Please check your organisation and repository name.');
      }
```
As suggested in the title of the issue, the fix implemented is to show a loading spinner while WATcher is changing repositories. This is indicated by a `BehaviorSubject` under `PhaseService`. `.next()` is used to indicate whether WATcher is changing repositories by updating `BehaviorSubject` before checking the validity of the repository, as well as after the repository is determined to be invalid or after the repository has been changed.

### Changes Made:

- Add `isChangingRepo` to `PhaseService` to indicate whether WATcher is changing repositories
- Modify `issue-viewer.component.html` to show a loading spinner depending on the value of `isChangingRepo`
- Modify `changeRepositoryInPhaseIfValid` in `header.component.ts` to update `isChangingRepo` accordingly

![loading_spinner](https://github.com/CATcher-org/WATcher/assets/105497890/13f8085a-521f-4dae-9806-9c5670cf2f1c)

### Commit Message:

```
Show loading spinner on switch repository

WATcher freezes before changing to new repository issues.

Let's show a loading spinner upon switching to a new repository.
```
