### PR TITLE
Add link to documentation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@
 **WAT**cher is a sister application to CATcher to be used to monitor software projects in a visual way, for educational use in particular.
 
 - [**WATcher Ideation Discussion Page**](https://github.com/CATcher-org/CATcher/discussions/938)
-- **WATcher Documentation Home** :construction:
-(under development) 
-  - Direct link to the **User Guide**
-  - Direct link to the **Developer Guide**
+- [**WATcher Documentation Home**](https://catcher-org.github.io/WATcher-docs/) :construction:
+  (under development)
+  - [Direct link to the **User Guide**](https://catcher-org.github.io/WATcher-docs/ug/)
+  - [Direct link to the **Developer Guide**](https://catcher-org.github.io/WATcher-docs/dg/)
+
+This project is based in [NUS School of Computing](https://www.comp.nus.edu.sg/), and part of the [NUS-OSS initiative](https://nus-oss.github.io/).
+
+Licence: MIT
+
+Contact: `seer@comp.nus.edu.sg`


### PR DESCRIPTION
### Summary:
Add link to documentation in Readme

### Commit Message:

```
Let's add link to WATcher-docs in Readme.
```
