### PR TITLE
Autofill repository URL with Browser Cache

### DIFF
--- a/src/app/auth/session-selection/session-selection.component.html
+++ b/src/app/auth/session-selection/session-selection.component.html
@@ -6,7 +6,17 @@
   <form [formGroup]="repoForm" (ngSubmit)="setupSession()">
     <mat-card-content>
       <mat-form-field class="login-field">
-        <input matInput placeholder="Repository Location (Org/Repo)" formControlName="repo" required />
+        <input
+          matInput
+          placeholder="Repository Location (Org/Repo)"
+          formControlName="repo"
+          required
+          [matAutocomplete]="auto"/>
+        <mat-autocomplete #auto="matAutocomplete">
+          <mat-option *ngFor="let suggestion of filteredSuggestions | async" [value]="suggestion">
+            {{suggestion}}
+          </mat-option>
+        </mat-autocomplete>
       </mat-form-field>
 
       <mat-card-actions>

--- a/src/app/auth/session-selection/session-selection.component.ts
+++ b/src/app/auth/session-selection/session-selection.component.ts
@@ -109,7 +109,15 @@ export class SessionSelectionComponent implements OnInit {
     });
   }
 
+  private formatRepoInformation(orgName: string, dataRepo: string): string {
+    return [orgName, dataRepo].join('/');
+  }
+
   private autofillRepo() {
-    this.repoForm.get('repo').setValue(this.urlEncodedRepo);
+    const repoOrg: string = window.localStorage.getItem('org');
+    const repoName: string = window.localStorage.getItem('dataRepo');
+    if (repoOrg && repoName) {
+      this.repoForm.get('repo').setValue(this.formatRepoInformation(repoOrg, repoName));
+    }
   }
 }

--- a/src/app/auth/session-selection/session-selection.component.ts
+++ b/src/app/auth/session-selection/session-selection.component.ts
@@ -72,8 +72,8 @@ export class SessionSelectionComponent implements OnInit {
     if (repoOrg && repoName) {
       window.localStorage.setItem('org', repoOrg);
       window.localStorage.setItem('dataRepo', repoName);
-      
-      // Update suggestions
+
+      // Update autofill repository URL suggestions in localStorage
       if (!this.suggestions.includes(repoInformation)) {
         this.suggestions.push(repoInformation);
         window.localStorage.setItem('suggestions', JSON.stringify(this.suggestions));
@@ -118,7 +118,7 @@ export class SessionSelectionComponent implements OnInit {
       repo: ['', Validators.required]
     });
     this.suggestions = JSON.parse(window.localStorage.getItem('suggestions')) || [];
-    // Ref: https://v10.material.angular.io/components/autocomplete/overview 
+    // Ref: https://v10.material.angular.io/components/autocomplete/overview
     this.filteredSuggestions = this.repoForm.get('repo').valueChanges
       .pipe(
         startWith(''),

--- a/src/app/auth/session-selection/session-selection.component.ts
+++ b/src/app/auth/session-selection/session-selection.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 import { Profile } from '../../core/models/profile.model';
 import { AuthService, AuthState } from '../../core/services/auth.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
@@ -15,6 +17,8 @@ export class SessionSelectionComponent implements OnInit {
   isSettingUpSession: boolean;
   profileForm: FormGroup;
   repoForm: FormGroup;
+  suggestions: string[];
+  filteredSuggestions: Observable<string[]>;
 
   @Input() urlEncodedSessionName: string;
   @Input() urlEncodedRepo: string;
@@ -68,6 +72,12 @@ export class SessionSelectionComponent implements OnInit {
     if (repoOrg && repoName) {
       window.localStorage.setItem('org', repoOrg);
       window.localStorage.setItem('dataRepo', repoName);
+      
+      // Update suggestions
+      if (!this.suggestions.includes(repoInformation)) {
+        this.suggestions.push(repoInformation);
+        window.localStorage.setItem('suggestions', JSON.stringify(this.suggestions));
+      }
     }
 
     this.logger.info(`SessionSelectionComponent: Selected Repository: ${repoInformation}`);
@@ -107,17 +117,16 @@ export class SessionSelectionComponent implements OnInit {
     this.repoForm = this.formBuilder.group({
       repo: ['', Validators.required]
     });
-  }
-
-  private formatRepoInformation(orgName: string, dataRepo: string): string {
-    return [orgName, dataRepo].join('/');
+    this.suggestions = JSON.parse(window.localStorage.getItem('suggestions')) || [];
+    // Ref: https://v10.material.angular.io/components/autocomplete/overview 
+    this.filteredSuggestions = this.repoForm.get('repo').valueChanges
+      .pipe(
+        startWith(''),
+        map(value => this.suggestions.filter(suggestion => suggestion.toLowerCase().includes(value.toLowerCase())))
+      );
   }
 
   private autofillRepo() {
-    const repoOrg: string = window.localStorage.getItem('org');
-    const repoName: string = window.localStorage.getItem('dataRepo');
-    if (repoOrg && repoName) {
-      this.repoForm.get('repo').setValue(this.formatRepoInformation(repoOrg, repoName));
-    }
+    this.repoForm.get('repo').setValue(this.urlEncodedRepo);
   }
 }

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -87,6 +87,14 @@ export class PhaseService {
       this.otherRepos.push(this.currentRepo); // TODO feature: can be used to provide repo suggestions
     }
     this.setRepository(repo, this.otherRepos);
+
+    // Update autofill repository URL suggestions in localStorage
+    const suggestions: string[] = JSON.parse(window.localStorage.getItem('suggestions')) || [];
+    if (!suggestions.includes(repo.toString())) {
+      suggestions.push(repo.toString());
+      window.localStorage.setItem('suggestions', JSON.stringify(suggestions));
+    }
+
     this.repoChanged$.next(repo);
   }
 

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -87,6 +87,16 @@ export class PhaseService {
       this.otherRepos.push(this.currentRepo); // TODO feature: can be used to provide repo suggestions
     }
     this.setRepository(repo, this.otherRepos);
+
+    /**
+     * Adapted from session-selection.component.ts
+     */
+    window.localStorage.removeItem('org');
+    window.localStorage.removeItem('dataRepo');
+
+    window.localStorage.setItem('org', repo.owner);
+    window.localStorage.setItem('dataRepo', repo.name);
+
     this.repoChanged$.next(repo);
   }
 

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -87,16 +87,6 @@ export class PhaseService {
       this.otherRepos.push(this.currentRepo); // TODO feature: can be used to provide repo suggestions
     }
     this.setRepository(repo, this.otherRepos);
-
-    /**
-     * Adapted from session-selection.component.ts
-     */
-    window.localStorage.removeItem('org');
-    window.localStorage.removeItem('dataRepo');
-
-    window.localStorage.setItem('org', repo.owner);
-    window.localStorage.setItem('dataRepo', repo.name);
-
     this.repoChanged$.next(repo);
   }
 

--- a/src/app/shared/repo-change-form/repo-change-form.component.html
+++ b/src/app/shared/repo-change-form/repo-change-form.component.html
@@ -2,7 +2,17 @@
 <div mat-dialog-content>
   <mat-form-field appearance="fill">
     <mat-label>Repository Location (Org/Repo)</mat-label>
-    <input matInput [(ngModel)]="this.repoName" />
+    <input 
+      matInput
+      [(ngModel)]="this.repoName"
+      [formControl]="repoChangeForm"
+      [matAutocomplete]="auto"
+    />
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let suggestion of filteredSuggestions | async" [value]="suggestion">
+        {{suggestion}}
+      </mat-option>
+    </mat-autocomplete>
   </mat-form-field>
 </div>
 <div mat-dialog-actions>

--- a/src/app/shared/repo-change-form/repo-change-form.component.ts
+++ b/src/app/shared/repo-change-form/repo-change-form.component.ts
@@ -1,18 +1,37 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-repo-change-form',
   templateUrl: './repo-change-form.component.html',
   styleUrls: ['./repo-change-form.component.css']
 })
-export class RepoChangeFormComponent {
+export class RepoChangeFormComponent implements OnInit {
   public repoName: String;
+  suggestions: string[];
+  filteredSuggestions: Observable<string[]>;
+  repoChangeForm = new FormControl();
 
   constructor(public dialogRef: MatDialogRef<RepoChangeFormComponent>, @Inject(MAT_DIALOG_DATA) public data) {
     this.repoName = data.repoName;
   }
 
+  ngOnInit() {
+    this.initRepoChangeForm();
+  }
+
+  private initRepoChangeForm() {
+    this.suggestions = JSON.parse(window.localStorage.getItem('suggestions')) || [];
+    // Ref: https://v10.material.angular.io/components/autocomplete/overview
+    this.filteredSuggestions = this.repoChangeForm.valueChanges
+      .pipe(
+        startWith(''),
+        map(value => this.suggestions.filter(suggestion => suggestion.toLowerCase().includes(value.toLowerCase())))
+      );
+  }
   onYesClick(): void {
     this.dialogRef.close(this.repoName);
   }


### PR DESCRIPTION
### Summary:

Resolves #30 
Update WATcher to show repository URL autofill suggestions when entering repository location.

![autofill_suggestion](https://github.com/CATcher-org/WATcher/assets/105497890/18de2b57-9991-4190-b2bf-ebc139a4cc66)

### Changes Made:

-`session-selection.component.html`: added `mat-autocomplete` to handle autofill suggestions
-`session-selection.component.ts`: modify `initRepoForm()` to retrieve suggestions from `localStorage` and set up filter, `setupSession()` to update suggestions in `localStorage`
-`repo-change-form.component.html`: added `mat-autocomplete` to handle autofill suggestions
-`repo-change-form.component.ts`: add `initRepoChangeForm()` to retrieve suggestions from `localStorage` and set up filter

### Commit Message:

```
Add autofill for repository URL with browser cache

Adding autofill suggestions for repository location would improve the
user experience when accessing WATcher again.

Let's add repository URL autofill suggestions with the browser cache.
```
