### PR TITLE
Extract method from header.component into phase.service.ts

### DIFF
--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -76,20 +76,23 @@ export class PhaseService {
 
   /**
    * Changes current respository to a new repository.
-   * If on Issue Dashboard, add previously visited repositories to otherRepos.
    * @param repo New current repository
    */
-  changeCurrentRepository(repo: Repo): void {
+  private changeCurrentRepository(repo: Repo): void {
     this.logger.info(`PhaseService: Changing current repository to '${repo}'`);
 
     if (this.currentPhase === Phase.issuesViewer) {
       /** Adds past repositories to phase */
-      this.otherRepos.push(this.currentRepo); // TODO feature: can be used to provide repo suggestions
+      this.otherRepos.push(this.currentRepo);
     }
     this.setRepository(repo, this.otherRepos);
     this.repoChanged$.next(repo);
   }
 
+  /**
+   * Change repository if a valid repository is provided
+   * @param repo New repository
+   */
   async changeRepositoryIfValid(repo: Repo) {
     this.isChangingRepo.next(true);
 

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -90,6 +90,19 @@ export class PhaseService {
     this.repoChanged$.next(repo);
   }
 
+  async changeRepositoryIfValid(repo: Repo) {
+    this.isChangingRepo.next(true);
+
+    const isValidRepository = await this.githubService.isRepositoryPresent(repo.owner, repo.name).toPromise();
+    if (!isValidRepository) {
+      this.isChangingRepo.next(false);
+      throw new Error('Invalid repository name. Please check your organisation and repository name.');
+    }
+
+    this.changeCurrentRepository(repo);
+    this.isChangingRepo.next(false);
+  }
+
   /**
    * Returns the full repository array of the current feature.
    */

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -194,26 +194,15 @@ export class HeaderComponent implements OnInit {
   }
 
   /**
-   * Change repository viewed on Issue Dashboard.
+   * Change repository viewed on Issue Dashboard, if a valid repository is provided.
    */
-  switchRepo(repo: Repo) {
-    this.phaseService.changeCurrentRepository(repo);
-    this.auth.setTitleWithPhaseDetail();
-  }
-
-  changeRepositoryInPhaseIfValid(repo: Repo, newRepoString: string) {
-    this.phaseService.isChangingRepo.next(true);
-
-    this.githubService.isRepositoryPresent(repo.owner, repo.name).subscribe((isValidRepository) => {
-      if (!isValidRepository) {
-        this.phaseService.isChangingRepo.next(false);
-        throw new Error('Invalid repository name. Please check your organisation and repository name.');
-      }
-
-      this.switchRepo(repo);
-      this.currentRepo = newRepoString;
-      this.phaseService.isChangingRepo.next(false);
-    });
+  changeRepositoryIfValid(repo: Repo, newRepoString: string) {
+      this.phaseService.changeRepositoryIfValid(repo)
+        .then(() => {
+          this.auth.setTitleWithPhaseDetail();
+          this.currentRepo = newRepoString;
+        })
+        .catch((error) => this.errorHandlingService.handleError(error));
   }
 
   openChangeRepoDialog() {
@@ -225,8 +214,7 @@ export class HeaderComponent implements OnInit {
       }
       const newRepo = Repo.of(res);
 
-      // instead of switching immediately, check if this is a valid repo first
-      this.changeRepositoryInPhaseIfValid(newRepo, res);
+      this.changeRepositoryIfValid(newRepo, res);
     });
   }
 }


### PR DESCRIPTION
### Summary:

Addresses https://github.com/CATcher-org/WATcher/pull/151#discussion_r1249395736
The nature of `changeRepositoryInPhaseIfValid()` makes it more suited to be in `phase.service` instead of `header.component`.

### Changes Made:

- Extract the relevant logic from `HeaderComponent::changeRepositoryInPhaseIfValid()` into a new method `PhaseService::changeRepositoryIfValid()`, and rename the original method to `HeaderComponent::changeRepositoryIfValid()`
- Remove `switchRepo()` and move method calls into `PhaseService::changeRepositoryIfValid()` and `HeaderComponent::changeRepositoryIfValid()` where appropriate

### Commit Message:

```
Extract method from header.component

changeRepositoryInPhaseIfValid() is more suited to phase.service than
header.component.

Let's extract the method into phase.service where appropriate.
```
