### PR TITLE
Collapse non-contributing user columns

### DIFF
--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -11,3 +11,7 @@ export interface GithubUser {
   updated_at: string;
   url: string;
 }
+
+export interface GithubUserWithHasIssues extends GithubUser {
+  hasIssues: boolean;
+}

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -367,7 +367,8 @@ export class GithubService {
     return from(
       octokit.issues.listAssignees({
         owner: ORG_NAME,
-        repo: REPO
+        repo: REPO,
+        per_page: 100
       })
     ).pipe(
       map((response) => {

--- a/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.css
+++ b/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.css
@@ -1,0 +1,78 @@
+.card-column {
+  margin: 8px;
+}
+
+.mat-card-title {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  text-align: left;
+  overflow: auto;
+  overflow-wrap: anywhere;
+}
+
+.column-header .mat-card-title {
+  font-size: 14px;
+}
+
+.mat-card {
+  padding: 10px;
+}
+
+:host ::ng-deep div.mat-card-header-text {
+  margin: 2px;
+}
+
+div.column-header .mat-card-title {
+  justify-content: center;
+  margin: 0;
+}
+
+div.column-header {
+  justify-content: center;
+  position: relative;
+  z-index: 1;
+}
+
+div.column-header .mat-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scrollable-container {
+  height: 53vh;
+  overflow: auto;
+  margin-bottom: 2px;
+  scrollbar-width: none;
+  position: relative;
+
+  /* Ref: https://css-scroll-shadows.vercel.app */
+  background: linear-gradient(white 33%, transparent), linear-gradient(transparent, white 66%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.5), transparent),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.5), transparent) 0 100%;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-attachment: local, local, scroll, scroll;
+  background-size: 100% 15px, 100% 15px, 100% 5px, 100% 5px;
+}
+
+.scrollable-container::-webkit-scrollbar {
+  display: none;
+}
+
+.user-cards .mat-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.loading-spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.html
+++ b/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.html
@@ -1,0 +1,31 @@
+<div class="card-column" [class.hidden]="this.usersToShow.length === 0">
+  <div class="column-header">
+    <mat-card>
+      <mat-card-header [ngStyle]="{ height: '40px' }">
+        <mat-card-title>Other Users</mat-card-title>
+      </mat-card-header>
+    </mat-card>
+  </div>
+
+  <div class="scrollable-container">
+    <div class="user-cards" *ngFor="let user of this.usersToShow; index as i">
+      <mat-card>
+        <div
+          mat-card-avatar
+          [ngStyle]="{
+            background: 'url(' + user.avatar_url + ')',
+            'background-size': '40px'
+          }"
+        ></div>
+        <mat-card-title>
+          {{ user.login }}
+        </mat-card-title>
+      </mat-card>
+    </div>
+    <mat-card class="loading-spinner" *ngIf="this.isLoading$ | async">
+      <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
+    </mat-card>
+  </div>
+
+  <mat-paginator [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>
+</div>

--- a/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.ts
+++ b/src/app/issues-viewer/card-view-other-users/card-view-other-users.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { MatPaginator } from '@angular/material/paginator';
+import { GithubUserWithHasIssues } from '../../core/models/github-user.model';
+import { IssueService } from '../../core/services/issue.service';
+import { paginateData } from '../../shared/issue-tables/issue-paginator';
+
+@Component({
+  selector: 'app-card-view-other-users',
+  templateUrl: './card-view-other-users.component.html',
+  styleUrls: ['./card-view-other-users.component.css']
+})
+export class CardViewOtherUsersComponent implements OnInit {
+  @Input() users?: GithubUserWithHasIssues[] = [];
+
+  usersToShow: GithubUserWithHasIssues[];
+
+  public isLoading$ = this.issueService.isLoading.asObservable();
+
+  constructor(private issueService: IssueService) {}
+
+  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+
+  ngOnInit(): void {
+    this.initialize();
+  }
+
+  /**
+   * Initializes the component.
+   */
+  private initialize() {
+    this.usersToShow = [];
+
+    this.isLoading$.subscribe((isLoading) => {
+      if (isLoading) {
+        return;
+      }
+      this.handlePagination();
+    });
+
+    this.paginator.page.subscribe(() => {
+      this.handlePagination();
+    });
+  }
+
+  /**
+   * Handles initializing and updating the pagination.
+   */
+  private handlePagination() {
+    const users = this.users.filter((user) => !user.hasIssues);
+    this.usersToShow = paginateData(this.paginator, users);
+  }
+}

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { Observable } from 'rxjs';
@@ -22,6 +22,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   @Input() assignee?: GithubUser = undefined;
   @Input() filters?: any = undefined;
   @Input() sort?: MatSort = undefined;
+  @Input() hasIssues!: boolean;
+  @Output() hasIssuesChange = new EventEmitter<boolean>();
 
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
@@ -38,6 +40,10 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
     setTimeout(() => {
       this.issues.loadIssues();
       this.issues$ = this.issues.connect();
+      this.issues$.subscribe((issues) => {
+        this.hasIssues = issues.length > 0;
+        this.hasIssuesChange.emit(this.hasIssues);
+      });
     });
   }
 

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -42,3 +42,7 @@
   justify-content: center;
   align-items: center;
 }
+
+.hidden {
+  display: none !important;
+}

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -1,11 +1,6 @@
 <div>
-  <div class="loading-spinner" *ngIf="this.phaseService.isChangingRepo | async; else elseBlock;">
-    <mat-progress-spinner 
-      color="primary"
-      mode="indeterminate"
-      diameter="50"
-      strokeWidth="5">
-    </mat-progress-spinner>
+  <div class="loading-spinner" *ngIf="this.phaseService.isChangingRepo | async; else elseBlock">
+    <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"> </mat-progress-spinner>
   </div>
 
   <ng-template #elseBlock>
@@ -18,6 +13,8 @@
         [assignee]="assignee"
         [headers]="this.displayedColumns"
         [sort]="filterbar.matSort"
+        [(hasIssues)]="assignee.hasIssues"
+        [class.hidden]="!assignee.hasIssues"
       ></app-card-view>
       <app-card-view class="issue-table" [headers]="this.displayedColumns" [sort]="filterbar.matSort"></app-card-view>
     </div>

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -17,6 +17,7 @@
         [class.hidden]="!assignee.hasIssues"
       ></app-card-view>
       <app-card-view class="issue-table" [headers]="this.displayedColumns" [sort]="filterbar.matSort"></app-card-view>
+      <app-card-view-other-users [users]="this.assignees"></app-card-view-other-users>
     </div>
   </ng-template>
 </div>

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { BehaviorSubject, of, Subscription } from 'rxjs';
-import { GithubUser } from '../core/models/github-user.model';
+import { GithubUserWithHasIssues } from '../core/models/github-user.model';
 import { Repo } from '../core/models/repo.model';
 import { GithubService } from '../core/services/github.service';
 import { IssueService } from '../core/services/issue.service';
@@ -24,7 +24,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   viewChange: Subscription;
 
   /** Users to show as columns */
-  assignees: GithubUser[];
+  assignees: GithubUserWithHasIssues[];
 
   @ViewChildren(CardViewComponent) cardViews: QueryList<CardViewComponent>;
 
@@ -68,7 +68,10 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     // Fetch assignees
     this.assignees = [];
 
-    this.githubService.getUsersAssignable().subscribe((x) => (this.assignees = x));
+    this.githubService.getUsersAssignable().subscribe((assignees) => {
+      // Defaults to false, so every user is initially hidden.
+      this.assignees = assignees.map((assignee) => ({ ...assignee, hasIssues: false }));
+    });
 
     // Fetch issues
     this.issueService.reloadAllIssues();

--- a/src/app/issues-viewer/issues-viewer.module.ts
+++ b/src/app/issues-viewer/issues-viewer.module.ts
@@ -3,13 +3,14 @@ import { MarkdownModule } from 'ngx-markdown';
 import { FilterBarModule } from '../shared/filter-bar/filter-bar.module';
 import { IssuesPrCardModule } from '../shared/issue-pr-card/issue-pr-card.module';
 import { SharedModule } from '../shared/shared.module';
+import { CardViewOtherUsersComponent } from './card-view-other-users/card-view-other-users.component';
 import { CardViewComponent } from './card-view/card-view.component';
 import { IssuesViewerRoutingModule } from './issues-viewer-routing.module';
 import { IssuesViewerComponent } from './issues-viewer.component';
 
 @NgModule({
   imports: [FilterBarModule, IssuesViewerRoutingModule, IssuesPrCardModule, SharedModule, MarkdownModule.forChild()],
-  declarations: [IssuesViewerComponent, CardViewComponent],
-  exports: [IssuesViewerComponent, CardViewComponent]
+  declarations: [IssuesViewerComponent, CardViewComponent, CardViewOtherUsersComponent],
+  exports: [IssuesViewerComponent, CardViewComponent, CardViewOtherUsersComponent]
 })
 export class IssuesViewerModule {}

--- a/src/app/shared/issue-tables/issue-paginator.ts
+++ b/src/app/shared/issue-tables/issue-paginator.ts
@@ -1,7 +1,6 @@
 import { MatPaginator } from '@angular/material/paginator';
-import { Issue } from '../../core/models/issue.model';
 
-export function paginateData(paginator: MatPaginator, data: Issue[]): Issue[] {
+export function paginateData<T>(paginator: MatPaginator, data: T[]): T[] {
   paginator.length = data.length;
   let result = getDataForPage(paginator.pageIndex, paginator.pageSize, data);
   if (result.length === 0) {
@@ -11,7 +10,7 @@ export function paginateData(paginator: MatPaginator, data: Issue[]): Issue[] {
   return result;
 }
 
-function getDataForPage(pageIndex: number, pageSize: number, data: Issue[]): Issue[] {
+function getDataForPage<T>(pageIndex: number, pageSize: number, data: T[]): T[] {
   const startIndex = pageIndex * pageSize;
   return data.splice(startIndex, pageSize);
 }


### PR DESCRIPTION
### Summary:

Fixes #156

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Hide non-contributing user columns
- Re-add non-contributing user columns as a new column on the far right (`card-view-other-users`)
  - This column is hidden if there are no non-contributing users (in other words, every user is contributing)
- User's contribution is affected by filters
- Increase `listAssignees` limit from default of `30` to `100`
  - API Documentation: https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#list-assignees
- Make `src/app/shared/issue-tables/issue-paginator.ts` accept a generic `T` instead of `Issue`

### Screenshots:

https://github.com/CATcher-org/WATcher/assets/47915290/52402c82-9f91-4f7c-89c1-c98faa3a831f

### Proposed Commit Message:

```
Collapse non-contributing user columns

Previously, users without any issues / PRs would have an empty column.

Let's
* Hide these user columns.
* Re-add these users into a new column `Other Users`
* Increase the `listAssignees` limit from default of `30` to `100` to support
  repositories with more users
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
