### PR TITLE
Change default color of octicons for assigned issues and PR's to green

### DIFF
--- a/src/app/user-detail-viewer/user-detail-viewer.component.ts
+++ b/src/app/user-detail-viewer/user-detail-viewer.component.ts
@@ -43,7 +43,7 @@ export class UserDetailViewerComponent implements OnInit, OnDestroy, AfterViewIn
     {
       octicon: 'issue-opened',
       title: 'Assigned Issues',
-      color: 'blue',
+      color: 'green',
       source$: this.userAssignedIssues$,
       isLoading$: this.issueService.isLoading.asObservable()
     },
@@ -57,7 +57,7 @@ export class UserDetailViewerComponent implements OnInit, OnDestroy, AfterViewIn
     {
       octicon: 'git-pull-request',
       title: 'Assigned PRs',
-      color: 'blue',
+      color: 'green',
       source$: this.userAssignedPRs$,
       isLoading$: this.issueService.isLoading.asObservable()
     },


### PR DESCRIPTION
### Summary: Change default color of octicons for assigned issues and PR's to green

Fixes #155 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

 Change the default blue color of octicons for assigned issues and assigned PR's to green to align with GitHub's style. 

### Screenshots:

![Ammended Colors](https://github.com/CATcher-org/WATcher/assets/70659811/62dc4f4f-e720-4d43-bc26-2a747f2cf638)

### Proposed Commit Message:

```
User detail viewer class: Octicons color in the assigned issue and 
assigned PR sections is blue.

The blue color does not have the desired visual representation and 
also it does not align with the current GitHub Octicons style. 

Let's change the color for the Octicons in these two sections from 
blue to green

The green color will ensure consistency with GitHub's style and will 
also improve visual aesthetics.  



Commit message to be used when the PR is merged
(NOTE: Wrap the body at 72 characters)
```

<details><summary>
<h3>Checklist:</h3>
</summary>



- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
