### PR TITLE
Throw error if there are too many pages to fetch

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -148,6 +148,8 @@ export class GithubService {
    * @returns Observable<boolean> that returns true if there are pages that do not exist in the cache model.
    */
   private toFetchIssues(filter: RestGithubIssueFilter): Observable<boolean> {
+    const pageFetchLimit = 100;
+
     let responseInFirstPage: GithubResponse<GithubIssue[]>;
     return this.getIssuesAPICall(filter, 1).pipe(
       map((response: GithubResponse<GithubIssue[]>) => {
@@ -156,6 +158,9 @@ export class GithubService {
       }),
       flatMap((numOfPages: number) => {
         const apiCalls: Observable<GithubResponse<GithubIssue[]>>[] = [];
+        if (numOfPages > pageFetchLimit) {
+          throw new Error(`Repository has too many pages (${numOfPages}), not supported.`);
+        }
         for (let i = 2; i <= numOfPages; i++) {
           apiCalls.push(this.getIssuesAPICall(filter, i));
         }

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, EMPTY, forkJoin, Observable, of, Subscription, throwError, timer } from 'rxjs';
-import { catchError, exhaustMap, finalize, flatMap, map } from 'rxjs/operators';
+import { BehaviorSubject, forkJoin, Observable, of, Subscription, throwError, timer } from 'rxjs';
+import { catchError, exhaustMap, finalize, map } from 'rxjs/operators';
 import RestGithubIssueFilter from '../models/github/github-issue-filter.model';
 import { GithubIssue } from '../models/github/github-issue.model';
 import { Issue, Issues, IssuesFilter } from '../models/issue.model';
@@ -43,9 +43,7 @@ export class IssueService {
         .pipe(
           exhaustMap(() => {
             return this.reloadAllIssues().pipe(
-              catchError(() => {
-                return EMPTY;
-              }),
+              catchError((err) => throwError(err)),
               finalize(() => this.isLoading.next(false))
             );
           })
@@ -151,6 +149,9 @@ export class IssueService {
         const outdatedIssueIds: Array<Number> = this.getOutdatedIssueIds(fetchedIssueIds);
         this.deleteIssuesFromLocalStore(outdatedIssueIds);
 
+        if (this.issues === undefined) {
+          return [];
+        }
         return Object.values(this.issues);
       })
     );


### PR DESCRIPTION
### Summary:

Fixes #32

#### Type of change:

- ✨ New Feature/ Enhancement
- 🐛 Bug Fix

### Changes Made:

- Change `toFetchIssues` to throw an error when the number of pages in a repository is more than `100`.
- Made change to `issue.service.ts` because to propagate the error upwards instead of silently returning an empty observable.
- After making the previous change, I noticed that there was an error thrown on empty repositories, which had previously been silently ignored, so I've fixed it by doing a simple conditional check with `this.issues === undefined`. (I've made the same change on #179 too)

I noticed that the application crashed within `toFetchIssues` when trying to make the REST api calls, i.e. it didn't even reach the graphql API stage. The REST api calls were made concurrently, so trying to cancel the already-made requests on a timeout would be more complicated, and does not have much benefits over a pre-determined limit. So, I made the check on the number of pages instead of a timeout for the graphql API.

### Screenshots:

https://github.com/CATcher-org/WATcher/assets/47915290/8280482b-b5bc-41eb-8118-8330275b6e18

- Tested on large repository `angular/angular`
- Tested on `catcher-org/catcher`, `catcher-org/watcher` (small to medium sized repositories)
- Tested on empty repository `seetohjinwei/catcher-test`

### Proposed Commit Message:

```
Throw error if there are too many pages to fetch

Previously, if a repository with too many pages was opened, the
application would hang or crash. This would not be a pleasant
experience if a user were to accidentally open such a repository.

Let's
* Detect this scenario and handle it elegantly with an error message.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
