### PR TITLE
Support private repos

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -121,7 +121,7 @@ export class AuthService {
   startOAuthProcess() {
     this.logger.info('AuthService: Starting authentication');
     // Available OAuth scopes https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
-    const githubRepoPermission = 'public_repo';
+    const githubRepoPermission = 'repo';
     this.changeAuthState(AuthState.AwaitingAuthentication);
 
     this.generateStateString();


### PR DESCRIPTION
### Summary:

Fixes #6 

Previously, WATcher only populates the issues/PRs of public repos. 

#### Type of change:

- ✨ Enhancement


### Changes Made:

- Change github repo permission to support private repos


### Proposed Commit Message:

```
Add support for private repos.

Let's allow users to use WATcher for their private repositories.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [X] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
