### PR TITLE
Improve efficiency of saving and deleting issue models

### DIFF
--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -92,12 +92,11 @@ export class IssueService {
    * @params shouldEmit - Whether the updated issues should be emitted to issues$.
    */
   updateLocalStore(issuesToUpdate: Issue[], shouldEmit: boolean = true) {
-    const newIssues = issuesToUpdate.reduce((obj, issue) => {
-      obj[issue.id] = issue;
-      return obj;
-    }, {});
-
-    this.issues = { ...this.issues, ...newIssues };
+    const newIssues = { ...this.issues };
+    issuesToUpdate.forEach((issue) => {
+      newIssues[issue.id] = issue;
+    });
+    this.issues = newIssues;
 
     if (shouldEmit) {
       this.issues$.next(Object.values(this.issues));

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -89,18 +89,15 @@ export class IssueService {
    * This function will update the issue's state of the application. This function needs to be called whenever a issue is added/updated.
    *
    * @params issuesToUpdate - An array of issues to update the state of the application with.
-   * @params shouldEmit - Whether the updated issues should be emitted to issues$.
    */
-  private updateLocalStore(issuesToUpdate: Issue[], shouldEmit: boolean = true) {
+  private updateLocalStore(issuesToUpdate: Issue[]) {
     const newIssues = { ...this.issues };
     issuesToUpdate.forEach((issue) => {
       newIssues[issue.id] = issue;
     });
     this.issues = newIssues;
 
-    if (shouldEmit) {
-      this.issues$.next(Object.values(this.issues));
-    }
+    this.issues$.next(Object.values(this.issues));
   }
 
   reset(resetSessionId: boolean) {
@@ -151,19 +148,19 @@ export class IssueService {
     );
   }
 
-  private createAndSaveIssueModels(githubIssues: GithubIssue[], shouldEmit: boolean = true): Issue[] {
+  private createAndSaveIssueModels(githubIssues: GithubIssue[]): Issue[] {
     const issues: Issue[] = [];
 
     for (const githubIssue of githubIssues) {
       const issue = this.createIssueModel(githubIssue);
       issues.push(issue);
     }
-    this.updateLocalStore(issues, shouldEmit);
+    this.updateLocalStore(issues);
 
     return issues;
   }
 
-  private deleteIssuesFromLocalStore(ids: number[], shouldEmit: boolean = true): void {
+  private deleteIssuesFromLocalStore(ids: number[]): void {
     const withoutIssuesToRemove = { ...this.issues };
     for (const id of ids) {
       delete withoutIssuesToRemove[id];
@@ -171,9 +168,7 @@ export class IssueService {
 
     this.issues = withoutIssuesToRemove;
 
-    if (shouldEmit) {
-      this.issues$.next(Object.values(this.issues));
-    }
+    this.issues$.next(Object.values(this.issues));
   }
 
   /**

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -91,7 +91,7 @@ export class IssueService {
    * @params issuesToUpdate - An array of issues to update the state of the application with.
    * @params shouldEmit - Whether the updated issues should be emitted to issues$.
    */
-  updateLocalStore(issuesToUpdate: Issue[], shouldEmit: boolean = true) {
+  private updateLocalStore(issuesToUpdate: Issue[], shouldEmit: boolean = true) {
     const newIssues = { ...this.issues };
     issuesToUpdate.forEach((issue) => {
       newIssues[issue.id] = issue;


### PR DESCRIPTION
### Summary:

Fixes #188 

#### Type of change:

- ✨ New Feature/ Enhancement
- 🎨 Code Refactoring

### Changes Made:

- Remove duplicate usage of `createIssueModel`
  - in 80be52fbb61c0f17010729a2c10f40ffe893bf74
- Change `updateLocalStore` to take in an array of issues to avoid having to do `O(n)` loops for each issue
  - in 80be52fbb61c0f17010729a2c10f40ffe893bf74
- Change `deleteIssuesFromLocalStore` to directly update `this.issues` using `delete` keyword, remove currently unused `deleteFromLocalStore`
  - in 2531a1e6a2f97c0a7d85fac5824693cd60a84b39

### Screenshots:

N/A

### Proposed Commit Message:

```
Improve efficiency of saving and deleting issue models

Previously, saving and deleting issues took up to O(n^2).

Let's
* Remove unnecessary loops to achieve O(n).
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
