### PR TITLE
Add a check to detect if no changes to currentRepo

### DIFF
--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -212,6 +212,9 @@ export class HeaderComponent implements OnInit {
    * Change repository viewed on Issue Dashboard, if a valid repository is provided.
    */
   changeRepositoryIfValid(repo: Repo, newRepoString: string) {
+    if (newRepoString === this.currentRepo) {
+      return;
+    }
     this.phaseService
       .changeRepositoryIfValid(repo)
       .then(() => {


### PR DESCRIPTION
### Summary:

Fixes #189 

#### Type of change:
- 🐛 Bug Fix

### Changes Made:
- Add a check to `changeRepositoryIfValid` method that if the newRepoString taken in from the `openChangeRepoDialog` is the same as the currently stored currentRepo displayed in the header, the phaseService to change the repo is not called

### Screenshots:
![fix-189](https://github.com/CATcher-org/WATcher/assets/110801974/afbe6c0a-6870-4b6e-89c9-c9b2629c076e)

### Proposed Commit Message:

```
Add a check to detect if newRepo string to change to is different from the currentRepo string

Previously, the phaseService would always be called to change the repository if the newRepoString is a valid repo

Let's
* first check if the newRepoString is different from the currentRepo before calling the phaseService to changeRepository
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [*] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [*] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
