### PR TITLE
Re-open Prompt for Invalid Repos

### DIFF
--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -218,6 +218,7 @@ export class HeaderComponent implements OnInit {
 
   /**
    * Change repository viewed on Issue Dashboard, if a valid repository is provided.
+   * Re-open dialog to prompt for another repository if an invalid one is provided.
    */
   changeRepositoryIfValid(repo: Repo, newRepoString: string) {
     if (newRepoString === this.currentRepo) {

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -229,7 +229,10 @@ export class HeaderComponent implements OnInit {
         this.auth.setTitleWithPhaseDetail();
         this.currentRepo = newRepoString;
       })
-      .catch((error) => this.errorHandlingService.handleError(error));
+      .catch((error) => {
+        this.openChangeRepoDialog();
+        this.errorHandlingService.handleError(error);
+      });
   }
 
   openChangeRepoDialog() {


### PR DESCRIPTION
### Summary:

Fixes #204 

#### Type of change:

- ✨  Enhancement


### Changes Made:

- Reopen `repo-change-form` when users try to change to an invalid repository

### Screenshots:


https://github.com/CATcher-org/WATcher/assets/97519138/b0dfd7bf-19f1-48e0-943d-bb1c0d3bccaa



### Proposed Commit Message:

```
Enhance error handling for switching to invalid repos.

Let's re-open the page to change repos when an invalid one is entered.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
