### PR TITLE
Fix closed draft pr colour

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.ts
@@ -48,11 +48,12 @@ export class IssuePrCardHeaderComponent {
 
   /** Returns status color for issue */
   getIssueOpenOrCloseColor() {
-    if (this.issue.isDraft) {
-      return 'grey';
-    }
     if (this.issue.state === 'OPEN') {
-      return 'green';
+      if (this.issue.isDraft) {
+        return 'grey';
+      } else {
+        return 'green';
+      }
     } else if (this.issue.issueOrPr === 'PullRequest' && this.issue.state === 'CLOSED') {
       return 'red';
     } else if (this.issue.issueOrPr === 'Issue' && this.issue.stateReason === 'NOT_PLANNED') {

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -24,11 +24,12 @@ export class IssuePrCardComponent {
 
   /** Returns CSS class for border color */
   getIssueOpenOrCloseColorCSSClass() {
-    if (this.issue.isDraft) {
-      return 'grey';
-    }
     if (this.issue.state === 'OPEN') {
-      return 'border-green';
+      if (this.issue.isDraft) {
+        return 'grey';
+      } else {
+        return 'border-green';
+      }
     } else if (this.issue.issueOrPr === 'PullRequest' && this.issue.state === 'CLOSED') {
       return 'border-red';
     } else if (this.issue.issueOrPr === 'Issue' && this.issue.stateReason === 'NOT_PLANNED') {


### PR DESCRIPTION
### Summary:

Fixes #218 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

Change the positioning of if statement in both the `getIssueOpenOrCloseColorCSSClass` and  `getIssueOpenOrCloseColor`

### Screenshots:

Before:
![278938965-0274a4fb-54d8-46b8-9f7e-d6fba8185c59](https://github.com/CATcher-org/WATcher/assets/89072240/a9d12762-4a02-4d20-9a87-a0e5d1f250d7)

After:
<img width="1278" alt="Screenshot 2023-11-19 012110" src="https://github.com/CATcher-org/WATcher/assets/89072240/33a0a57d-9960-4577-adf6-7071e2ab014f">


### Proposed Commit Message:

```
Fix color for closed draft PR display

This commit addresses a UI issue where the color of closed draft pull requests
was not displayed correctly.

```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
