### PR TITLE
Show label filters scrollbar when scrollable

### DIFF
--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
@@ -23,8 +23,6 @@
   width: 100%;
   overflow-y: auto;
   position: relative;
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
 }
 
 /* Ref: https://css-scroll-shadows.vercel.app */
@@ -77,10 +75,6 @@
   right: 0;
   height: 5px;
   background-image: radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.7), transparent);
-}
-
-.scroll-container::-webkit-scrollbar {
-  display: none; /* Hide scrollbar for Chrome, Safari and Opera */
 }
 
 .flexbox-container {


### PR DESCRIPTION
### Summary:

Fixes #17 

### Changes Made:

- Remove `display: none` of `.scroll-container::-webkit-scrollbar`
- Remove `-ms-overflow-style: none` and `scrollbar-width: none` in `.scroll-container`

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/107099783/01347dc7-72b4-4ccf-a060-de35c9e4c2e2)
![image](https://github.com/CATcher-org/WATcher/assets/107099783/75adafdc-93c2-4378-a7c3-a6ca41c5bf12)
