### PR TITLE
Prevent redirection when repo not set

### DIFF
--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -8,7 +8,10 @@
   >
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
-  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase"
+  <a
+    class="mat-toolbar mat-primary"
+    style="text-decoration: none"
+    [routerLink]="phaseService.isRepoSet() ? phaseService.currentPhase : null"
     >WATcher v{{ this.getVersion() }}</a
   >
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">


### PR DESCRIPTION
### Summary:

Fixes #224

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Added a check to WATcher logo hyperlink and disable when repo has not been set

### Screenshots:

![Untitled design](https://github.com/CATcher-org/WATcher/assets/114080910/6e2a9dcc-74fc-4959-970e-d2e72248e985)


### Proposed Commit Message:

```
Prevent redirection using WATcher logo when repo has not been set

Conditionally redirecting prevents error messages shown before.

Let's redirect to `null` if repository has not been set.
```
