### PR TITLE
Fix label filter not working

### DIFF
--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -23,7 +23,7 @@
           <mat-list-option
             #option
             *ngFor="let label of this.labels$ | async"
-            [value]="label.name"
+            [value]="label.formattedName"
             [selected]="selectedLabelNames.includes(label.name)"
             class="list-option"
             [class.hidden]="filter(input.value, label.name)"

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -24,20 +24,28 @@
             #option
             *ngFor="let label of this.labels$ | async"
             [value]="label.formattedName"
-            [selected]="selectedLabelNames.includes(label.name)"
+            [selected]="selectedLabelNames.includes(label.formattedName)"
             class="list-option"
             [class.hidden]="filter(input.value, label.name)"
           >
             <div class="flexbox-container">
-              <button mat-icon-button *ngIf="!hiddenLabelNames.has(label.name)" (click)="hide(label.name); $event.stopPropagation()">
+              <button
+                mat-icon-button
+                *ngIf="!hiddenLabelNames.has(label.formattedName)"
+                (click)="hide(label.formattedName); $event.stopPropagation()"
+              >
                 <mat-icon>visibility</mat-icon>
               </button>
-              <button mat-icon-button *ngIf="hiddenLabelNames.has(label.name)" (click)="show(label.name); $event.stopPropagation()">
+              <button
+                mat-icon-button
+                *ngIf="hiddenLabelNames.has(label.formattedName)"
+                (click)="show(label.formattedName); $event.stopPropagation()"
+              >
                 <mat-icon>visibility_off</mat-icon>
               </button>
               <mat-chip
                 [ngStyle]="labelService.setLabelStyle(label.color)"
-                [disabled]="hiddenLabelNames.has(label.name)"
+                [disabled]="hiddenLabelNames.has(label.formattedName)"
                 (click)="simulateClick(option); $event.stopPropagation()"
               >
                 {{ label.formattedName }}


### PR DESCRIPTION
### Summary:

Fixes #227 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

Change the value on the model of `label-filter-bar` component from `label.name` to `label.formattedName`.
The value is used to update the filters on issues and PRs.

The error toast shows because on one click, two filters are applied. I believe this is unintentional.
By changing the value to `label.formattedName`, only one filter is applied (assuming that each label formatted name is unique).

The filter also does not work when the label has 2 parts separated by a period `.`.

Note that the filter still does not work with labels with 2 or more periods `.`. This is because of how `Label`s are constructed. Please see #229 .

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/91e401d5-6e22-4cab-a411-087e03e1d2d8)

### Proposed Commit Message:

```
Fix label filter not working

Filters takes the value of `label.formattedName` instead of `label.name`.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
