### PR TITLE
Refactor Label model

### DIFF
--- a/src/app/core/models/label.model.ts
+++ b/src/app/core/models/label.model.ts
@@ -2,12 +2,12 @@
  * Represents a label and its attributes.
  */
 export class Label implements SimpleLabel {
-  readonly formattedName: string;
+  readonly name: string;
   color: string;
   definition?: string;
 
   constructor(label: { name: string; color: string; definition?: string }) {
-    this.formattedName = label.name;
+    this.name = label.name;
     this.color = label.color;
     this.definition = label.definition;
   }
@@ -17,6 +17,6 @@ export class Label implements SimpleLabel {
  * Represents a simplified label with name and color
  */
 export type SimpleLabel = {
-  formattedName: string;
+  name: string;
   color: string;
 };

--- a/src/app/core/models/label.model.ts
+++ b/src/app/core/models/label.model.ts
@@ -2,22 +2,14 @@
  * Represents a label and its attributes.
  */
 export class Label implements SimpleLabel {
-  readonly category: string;
-  readonly name: string;
-  readonly formattedName: string; // 'category'.'name' (e.g. severity.Low) if a category exists or 'name' if the category does not exist.
+  readonly formattedName: string;
   color: string;
   definition?: string;
 
   constructor(label: { name: string; color: string; definition?: string }) {
-    const containsDotRegex = /\.\b/g; // contains dot in middle of name
-    [this.category, this.name] = containsDotRegex.test(label.name) ? label.name.split('.') : [undefined, label.name];
-    this.formattedName = this.category === undefined || this.category === '' ? this.name : this.category.concat('.', this.name);
+    this.formattedName = label.name;
     this.color = label.color;
     this.definition = label.definition;
-  }
-
-  public equals(label: Label) {
-    return this.name === label.name && this.category === label.category;
   }
 }
 

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -23,32 +23,24 @@
           <mat-list-option
             #option
             *ngFor="let label of this.labels$ | async"
-            [value]="label.formattedName"
-            [selected]="selectedLabelNames.includes(label.formattedName)"
+            [value]="label.name"
+            [selected]="selectedLabelNames.includes(label.name)"
             class="list-option"
-            [class.hidden]="filter(input.value, label.formattedName)"
+            [class.hidden]="filter(input.value, label.name)"
           >
             <div class="flexbox-container">
-              <button
-                mat-icon-button
-                *ngIf="!hiddenLabelNames.has(label.formattedName)"
-                (click)="hide(label.formattedName); $event.stopPropagation()"
-              >
+              <button mat-icon-button *ngIf="!hiddenLabelNames.has(label.name)" (click)="hide(label.name); $event.stopPropagation()">
                 <mat-icon>visibility</mat-icon>
               </button>
-              <button
-                mat-icon-button
-                *ngIf="hiddenLabelNames.has(label.formattedName)"
-                (click)="show(label.formattedName); $event.stopPropagation()"
-              >
+              <button mat-icon-button *ngIf="hiddenLabelNames.has(label.name)" (click)="show(label.name); $event.stopPropagation()">
                 <mat-icon>visibility_off</mat-icon>
               </button>
               <mat-chip
                 [ngStyle]="labelService.setLabelStyle(label.color)"
-                [disabled]="hiddenLabelNames.has(label.formattedName)"
+                [disabled]="hiddenLabelNames.has(label.name)"
                 (click)="simulateClick(option); $event.stopPropagation()"
               >
-                {{ label.formattedName }}
+                {{ label.name }}
               </mat-chip>
             </div>
           </mat-list-option>

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -26,7 +26,7 @@
             [value]="label.formattedName"
             [selected]="selectedLabelNames.includes(label.formattedName)"
             class="list-option"
-            [class.hidden]="filter(input.value, label.name)"
+            [class.hidden]="filter(input.value, label.formattedName)"
           >
             <div class="flexbox-container">
               <button

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -96,7 +96,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     if (this.allLabels === undefined || this.allLabels.length === 0) {
       return false;
     }
-    return this.allLabels.some((label) => !this.filter(filter, label.formattedName));
+    return this.allLabels.some((label) => !this.filter(filter, label.name));
   }
 
   updateSelection(): void {

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Label } from '../../../core/models/label.model';
+import { GithubLabel } from '../../../core/models/github/github-label.model';
 import { LabelService } from '../../../core/services/label.service';
 
 @Component({
@@ -8,7 +8,7 @@ import { LabelService } from '../../../core/services/label.service';
   styleUrls: ['./issue-pr-card-labels.component.css']
 })
 export class IssuePrCardLabelsComponent {
-  @Input() labels: Label[];
-  @Input() labelSet: Set<Label>;
+  @Input() labels: GithubLabel[];
+  @Input() labelSet: Set<string>;
   constructor(public labelService: LabelService) {}
 }


### PR DESCRIPTION
### Summary:

Fixes #229

#### Type of change:

- 🐛 Bug Fix
- 🎨 Code Refactoring

### Changes Made:

As also discussed in #230, there isn't a need for separation of label full name into label name and label category. `Label::name` and `Label::category` are completely removed. Components now make use of `Label::formattedName` instead.

With this change, `Label::formattedName` is the label's full name instead of (previously) only the first two parts, hence filters would work as expected regardless of number of periods `.` in the label name.

One consequence of this change is that dropdown filter searching now would search in "category" part of labels as well. For example, when searching "cat" in the dropdown for this repo:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/3983ff6a-f636-4862-aa5f-20a532bbb704)

All the labels with name `category.*` will be included. Previously, with the separation of label full name into name and category, only `duplicate` label is included. I believe that now with the removal of the aforementioned separation, the inclusion of `category.*` is necessary.

While searching for the use of `Label::name`, I found out that the `IssuePrCardLabelsComponent` has wrong type annotations. I hence have made correction to the type annotations.

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/444ec0be-2ea7-4679-a4a1-f270d7fcee8b)

### Proposed Commit Message:

```
Refactor Label model

Previously, label full names are separated into label name
and label category. However, this is not necessary for WATcher.

Let's remove the separation so that filters only make use
of the full name.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
