### PR TITLE
Refactor test cases for Label Service

### DIFF
--- a/tests/constants/label.constants.ts
+++ b/tests/constants/label.constants.ts
@@ -1,26 +1,36 @@
-import { Label } from '../../src/app/core/models/label.model';
-import { LabelService, LABEL_DEFINITIONS } from '../../src/app/core/services/label.service';
-
 // Label name constants
 export const SEVERITY_VERY_LOW = 'Very Low';
 export const SEVERITY_LOW = 'Low';
 export const SEVERITY_MEDIUM = 'Medium';
 export const SEVERITY_HIGH = 'High';
-export const TYPE_DOCUMENTATION_BUG = 'DocumentationBug';
-export const TYPE_FUNCTIONALITY_BUG = 'FunctionalityBug';
-export const TYPE_FEATURE_FLAW = 'FeatureFlaw';
-export const RESPONSE_ACCEPTED = 'Accepted';
-export const RESPONSE_REJECTED = 'Rejected';
-export const RESPONSE_ISSUE_UNCLEAR = 'IssueUnclear';
-export const RESPONSE_CANNOT_REPRODUCE = 'CannotReproduce';
-export const STATUS_DONE = 'Done';
-export const STATUS_INCOMPLETE = 'Incomplete';
 
 // Label category constants
-export const SEVERITY = 'severity';
-export const TYPE = 'type';
-export const RESPONSE = 'response';
-export const STATUS = 'status';
+export const CATEGORY_SEVERITY = 'severity';
+
+// Label name constants
+export const LABEL_NAME_SEVERITY_VERY_LOW = CATEGORY_SEVERITY + '.' + SEVERITY_VERY_LOW;
+export const LABEL_NAME_SEVERITY_LOW = CATEGORY_SEVERITY + '.' + SEVERITY_LOW;
+export const LABEL_NAME_SEVERITY_MEDIUM = CATEGORY_SEVERITY + '.' + SEVERITY_MEDIUM;
+export const LABEL_NAME_SEVERITY_HIGH = CATEGORY_SEVERITY + '.' + SEVERITY_HIGH;
+
+// Label definition constants
+export const DEFINITION_SEVERITY_VERY_LOW =
+  '<p>A flaw that is <mark>purely cosmetic</mark> and <mark>does not affect usage</mark>. For example, ' +
+  '<ul>' +
+  '<li>typo issues</li>' +
+  '<li>spacing issues</li>' +
+  '<li>layout issues</li>' +
+  '<li>color issues</li>' +
+  '<li>font issues</li>' +
+  '</ul>' +
+  "in the docs or the UI that doesn't affect usage.</p>";
+export const DEFINITION_SEVERITY_LOW =
+  '<p>A flaw that is unlikely to affect normal operations of the product. ' +
+  'Appears only in very rare situations and causes a minor inconvenience only.</p>';
+export const DEFINITION_SEVERITY_MEDIUM =
+  '<p>A flaw that causes occasional inconvenience to some users but they can ' + 'continue to use the product.</p>';
+export const DEFINITION_SEVERITY_HIGH =
+  '<p>A flaw that affects most users and causes major problems for users.' + 'i.e., makes the product almost unusable for most users.</p>';
 
 // Label color constants
 export const COLOR_BLACK = '000000';
@@ -29,114 +39,38 @@ export const COLOR_SEVERITY_VERY_LOW = 'ffe0e0';
 export const COLOR_SEVERITY_LOW = 'ffcccc';
 export const COLOR_SEVERITY_MEDIUM = 'ff9999';
 export const COLOR_SEVERITY_HIGH = 'ff6666';
-export const COLOR_TYPE_DOCUMENTATION_BUG = 'd966ff';
-export const COLOR_TYPE_FUNCTIONALITY_BUG = '9900cc';
-export const COLOR_RESPONSE_ACCEPTED = '00802b';
-export const COLOR_RESPONSE_REJECTED = 'ff9900';
-export const COLOR_RESPONSE_ISSUE_UNCLEAR = 'ffcc80';
-export const COLOR_RESPONSE_CANNOT_REPRODUCE = 'ffebcc';
-export const COLOR_STATUS_DONE = 'a6a6a6';
-export const COLOR_STATUS_INCOMPLETE = '000000';
-
-export const CSS_BORDER_RADIUS_3PX = '3px';
-export const CSS_CURSOR_DEFAULT = 'default';
-export const CSS_PADDING_3PX = '3px';
-export const CSS_FONT_WEIGHT_410 = '410';
-export const CSS_DISPLAY_INLINE_FLEX = 'inline-flex';
-export const CSS_DISPLAY_INLINE_BLOCK = 'inline-block';
 
 // CSS style constants
 export const DARK_BG_LIGHT_TEXT = {
   'background-color': `#${COLOR_BLACK}`,
-  'border-radius': CSS_BORDER_RADIUS_3PX,
-  cursor: CSS_CURSOR_DEFAULT,
-  padding: CSS_PADDING_3PX,
-  color: `#${COLOR_WHITE}`,
-  'font-weight': CSS_FONT_WEIGHT_410,
-  display: CSS_DISPLAY_INLINE_FLEX
+  color: `#${COLOR_WHITE}`
 };
 
 export const LIGHT_BG_DARK_TEXT = {
   'background-color': `#${COLOR_WHITE}`,
-  'border-radius': CSS_BORDER_RADIUS_3PX,
-  cursor: CSS_CURSOR_DEFAULT,
-  padding: CSS_PADDING_3PX,
-  color: `#${COLOR_BLACK}`,
-  'font-weight': CSS_FONT_WEIGHT_410,
-  display: CSS_DISPLAY_INLINE_FLEX
+  color: `#${COLOR_BLACK}`
 };
-
-export const INLINE_BLOCK_TEXT = {
-  'background-color': `#${COLOR_WHITE}`,
-  'border-radius': CSS_BORDER_RADIUS_3PX,
-  cursor: CSS_CURSOR_DEFAULT,
-  padding: CSS_PADDING_3PX,
-  color: `#${COLOR_BLACK}`,
-  'font-weight': CSS_FONT_WEIGHT_410,
-  display: CSS_DISPLAY_INLINE_BLOCK
-};
-
-export const RESPONSE_REJECTED_LABEL = new Label(RESPONSE, RESPONSE_REJECTED, COLOR_RESPONSE_REJECTED, LABEL_DEFINITIONS.responseRejected);
-export const STATUS_DONE_LABEL = new Label(STATUS, STATUS_DONE, COLOR_STATUS_DONE);
-
-export const TYPE_DOCUMENTATION_BUG_LABEL = new Label(
-  TYPE,
-  TYPE_DOCUMENTATION_BUG,
-  COLOR_TYPE_DOCUMENTATION_BUG,
-  LABEL_DEFINITIONS.typeDocumentationBug
-);
-export const TYPE_FUNCTIONALITY_BUG_LABEL = new Label(
-  TYPE,
-  TYPE_FUNCTIONALITY_BUG,
-  COLOR_TYPE_FUNCTIONALITY_BUG,
-  LABEL_DEFINITIONS.typeFunctionalityBug
-);
-
-export const SEVERITY_HIGH_LABEL = new Label(SEVERITY, SEVERITY_HIGH, COLOR_SEVERITY_HIGH, LABEL_DEFINITIONS.severityHigh);
-export const SEVERITY_MEDIUM_LABEL = new Label(SEVERITY, SEVERITY_MEDIUM, COLOR_SEVERITY_MEDIUM, LABEL_DEFINITIONS.severityMedium);
-export const SEVERITY_LOW_LABEL = new Label(SEVERITY, SEVERITY_LOW, COLOR_SEVERITY_LOW, LABEL_DEFINITIONS.severityLow);
 
 // Constant array of labels for team response phase and moderation phase to simulate Github response
-export const SOME_TEAM_RESPONSE_PHASE_LABELS = [
-  {
-    color: COLOR_RESPONSE_ACCEPTED,
-    name: RESPONSE + '.' + RESPONSE_ACCEPTED,
-    definition: LABEL_DEFINITIONS.responseAccepted
-  },
-  {
-    color: COLOR_SEVERITY_LOW,
-    name: SEVERITY + '.' + SEVERITY_LOW,
-    definition: LABEL_DEFINITIONS.severityLow
-  },
-  {
-    color: COLOR_TYPE_FUNCTIONALITY_BUG,
-    name: TYPE + '.' + TYPE_FUNCTIONALITY_BUG,
-    definition: LABEL_DEFINITIONS.typeFunctionalityBug
-  }
-];
-
-// Constant array of labels for tester phase to simulate Github response
-export const SOME_TESTER_PHASE_LABELS = [
-  {
-    color: COLOR_SEVERITY_HIGH,
-    name: SEVERITY + '.' + SEVERITY_HIGH
-  },
-  {
-    color: COLOR_TYPE_DOCUMENTATION_BUG,
-    name: TYPE + '.' + TYPE_DOCUMENTATION_BUG
-  }
-];
-
-export const ALL_REQUIRED_LABELS_ARRAY: {}[] = LabelService.getRequiredLabelsAsArray(true).map((label: Label) => {
-  return {
-    color: label.labelColor,
-    name: label.getFormattedName()
-  };
-});
-
-// List of labels
 export const SEVERITY_LABELS = [
-  new Label(SEVERITY, SEVERITY_LOW, COLOR_SEVERITY_LOW, LABEL_DEFINITIONS.severityLow),
-  new Label(SEVERITY, SEVERITY_MEDIUM, COLOR_SEVERITY_MEDIUM, LABEL_DEFINITIONS.severityMedium),
-  new Label(SEVERITY, SEVERITY_HIGH, COLOR_SEVERITY_HIGH, LABEL_DEFINITIONS.undefined)
+  {
+    name: LABEL_NAME_SEVERITY_VERY_LOW,
+    color: COLOR_SEVERITY_VERY_LOW,
+    definition: DEFINITION_SEVERITY_VERY_LOW
+  },
+  {
+    name: LABEL_NAME_SEVERITY_LOW,
+    color: COLOR_SEVERITY_LOW,
+    definition: DEFINITION_SEVERITY_LOW
+  },
+  {
+    name: LABEL_NAME_SEVERITY_MEDIUM,
+    color: COLOR_SEVERITY_MEDIUM,
+    definition: DEFINITION_SEVERITY_MEDIUM
+  },
+  {
+    name: LABEL_NAME_SEVERITY_HIGH,
+    color: COLOR_SEVERITY_HIGH,
+    definition: DEFINITION_SEVERITY_HIGH
+  }
 ];

--- a/tests/services/label.service.spec.ts
+++ b/tests/services/label.service.spec.ts
@@ -1,100 +1,42 @@
-import { of } from 'rxjs';
 import { Label } from '../../src/app/core/models/label.model';
-import { LabelService, LABEL_DEFINITIONS } from '../../src/app/core/services/label.service';
+import { LabelService } from '../../src/app/core/services/label.service';
 import * as LabelConstant from '../constants/label.constants';
 
 let labelService: LabelService;
 let labelList: Label[];
-let githubService: any;
-
-describe('LabelService', () => {
-  beforeEach(() => {
-    githubService = jasmine.createSpyObj('GithubService', ['fetchAllLabels', 'createLabel']);
-    labelService = new LabelService(githubService);
-  });
-
-  describe('.syncLabels()', () => {
-    it('should create all required labels for team response phase if no required labels are fetched', () => {
-      githubService.fetchAllLabels.and.callFake(() => of([]));
-      of(true).pipe(labelService.syncLabels(true)).subscribe();
-
-      assertLabelCreated(githubService, LabelConstant.SEVERITY_LOW_LABEL);
-      assertLabelCreated(githubService, LabelConstant.RESPONSE_REJECTED_LABEL);
-      assertLabelCreated(githubService, LabelConstant.STATUS_DONE_LABEL);
-      assertLabelCreated(githubService, LabelConstant.TYPE_DOCUMENTATION_BUG_LABEL);
-      expect(githubService.createLabel).toHaveBeenCalledTimes(LabelService.getRequiredLabelsAsArray(true).length);
-    });
-
-    it('should create all required labels for tester phase if no required labels are fetched', () => {
-      githubService.fetchAllLabels.and.callFake(() => of([]));
-      of(true).pipe(labelService.syncLabels(false)).subscribe();
-
-      assertLabelCreated(githubService, LabelConstant.SEVERITY_LOW_LABEL);
-      assertLabelCreated(githubService, LabelConstant.TYPE_DOCUMENTATION_BUG_LABEL);
-      expect(githubService.createLabel).toHaveBeenCalledTimes(LabelService.getRequiredLabelsAsArray(false).length);
-    });
-
-    it('should create missing required labels for team response phase if some required labels are fetched', () => {
-      githubService.fetchAllLabels.and.callFake(() => of(LabelConstant.SOME_TEAM_RESPONSE_PHASE_LABELS));
-      of(true).pipe(labelService.syncLabels(true)).subscribe();
-
-      assertLabelNotCreated(githubService, LabelConstant.SEVERITY_LOW_LABEL);
-      assertLabelCreated(githubService, LabelConstant.RESPONSE_REJECTED_LABEL);
-      assertLabelCreated(githubService, LabelConstant.STATUS_DONE_LABEL);
-      assertLabelCreated(githubService, LabelConstant.TYPE_DOCUMENTATION_BUG_LABEL);
-      expect(githubService.createLabel).toHaveBeenCalledTimes(
-        LabelService.getRequiredLabelsAsArray(true).length - LabelConstant.SOME_TEAM_RESPONSE_PHASE_LABELS.length
-      );
-    });
-
-    it('should create missing required labels for tester phase if some required labels are fetched', () => {
-      githubService.fetchAllLabels.and.callFake(() => of(LabelConstant.SOME_TESTER_PHASE_LABELS));
-      of(true).pipe(labelService.syncLabels(false)).subscribe();
-
-      assertLabelNotCreated(githubService, LabelConstant.SEVERITY_HIGH_LABEL);
-      assertLabelCreated(githubService, LabelConstant.TYPE_FUNCTIONALITY_BUG_LABEL);
-      expect(githubService.createLabel).toHaveBeenCalledTimes(
-        LabelService.getRequiredLabelsAsArray(false).length - LabelConstant.SOME_TESTER_PHASE_LABELS.length
-      );
-    });
-
-    it('should not need to create any required labels if all required labels are fetched', () => {
-      githubService.fetchAllLabels.and.callFake(() => of(LabelConstant.ALL_REQUIRED_LABELS_ARRAY));
-      of(true).pipe(labelService.syncLabels(true)).subscribe();
-
-      expect(githubService.createLabel).toHaveBeenCalledTimes(0);
-    });
-  });
-});
 
 describe('LabelService: parseLabelData()', () => {
   beforeAll(() => {
     labelService = new LabelService(null);
-    labelList = labelService.parseLabelData(LabelConstant.SOME_TEAM_RESPONSE_PHASE_LABELS);
+    labelList = labelService.parseLabelData(LabelConstant.SEVERITY_LABELS);
   });
 
   afterAll(() => {
     labelService = null;
   });
 
-  it('should be response.Accepted label', () => {
-    expect(labelList[0].labelCategory).toBe(LabelConstant.RESPONSE);
-    expect(labelList[0].labelValue).toBe(LabelConstant.RESPONSE_ACCEPTED);
-    expect(labelList[0].labelColor).toBe(LabelConstant.COLOR_RESPONSE_ACCEPTED);
+  it('should be severity very low label', () => {
+    expect(labelList[0].name).toBe(LabelConstant.LABEL_NAME_SEVERITY_VERY_LOW);
+    expect(labelList[0].color).toBe(LabelConstant.COLOR_SEVERITY_VERY_LOW);
+    expect(labelList[0].definition).toBe(LabelConstant.DEFINITION_SEVERITY_VERY_LOW);
   });
 
-  it('should be severity.Low', () => {
-    expect(labelList[1].labelCategory).toBe(LabelConstant.SEVERITY);
-    expect(labelList[1].labelValue).toBe(LabelConstant.SEVERITY_LOW);
-    expect(labelList[1].labelColor).toBe(LabelConstant.COLOR_SEVERITY_LOW);
-    expect(labelList[1].labelDefinition).toBe(LABEL_DEFINITIONS.severityLow);
+  it('should be severity low label', () => {
+    expect(labelList[1].name).toBe(LabelConstant.LABEL_NAME_SEVERITY_LOW);
+    expect(labelList[1].color).toBe(LabelConstant.COLOR_SEVERITY_LOW);
+    expect(labelList[1].definition).toBe(LabelConstant.DEFINITION_SEVERITY_LOW);
   });
 
-  it('should be type.FunctionalityBug', () => {
-    expect(labelList[2].labelCategory).toBe(LabelConstant.TYPE);
-    expect(labelList[2].labelValue).toBe(LabelConstant.TYPE_FUNCTIONALITY_BUG);
-    expect(labelList[2].labelColor).toBe(LabelConstant.COLOR_TYPE_FUNCTIONALITY_BUG);
-    expect(labelList[2].labelDefinition).toBe(LABEL_DEFINITIONS.typeFunctionalityBug);
+  it('should be severity medium label', () => {
+    expect(labelList[2].name).toBe(LabelConstant.LABEL_NAME_SEVERITY_MEDIUM);
+    expect(labelList[2].color).toBe(LabelConstant.COLOR_SEVERITY_MEDIUM);
+    expect(labelList[2].definition).toBe(LabelConstant.DEFINITION_SEVERITY_MEDIUM);
+  });
+
+  it('should be severity high label', () => {
+    expect(labelList[3].name).toBe(LabelConstant.LABEL_NAME_SEVERITY_HIGH);
+    expect(labelList[3].color).toBe(LabelConstant.COLOR_SEVERITY_HIGH);
+    expect(labelList[3].definition).toBe(LabelConstant.DEFINITION_SEVERITY_HIGH);
   });
 });
 
@@ -132,72 +74,4 @@ describe('LabelService: setLabelStyle()', () => {
   it('should be light color background with dark color text', () => {
     expect(labelService.setLabelStyle(LabelConstant.COLOR_WHITE)).toEqual(LabelConstant.LIGHT_BG_DARK_TEXT);
   });
-
-  it('should be light color background with dark color text', () => {
-    expect(labelService.setLabelStyle(LabelConstant.COLOR_WHITE, 'inline-block')).toEqual(LabelConstant.INLINE_BLOCK_TEXT);
-  });
 });
-
-describe('LabelService: getColorOfLabel()', () => {
-  beforeEach(() => {
-    labelService = new LabelService(null);
-  });
-
-  afterEach(() => {
-    labelService = null;
-  });
-
-  it('should be correct label color for Severity.Low', () => {
-    expect(labelService.getColorOfLabel(LabelConstant.SEVERITY_LOW)).toEqual(LabelConstant.COLOR_SEVERITY_LOW);
-  });
-
-  it('should be white color for invalid inputs', () => {
-    expect(labelService.getColorOfLabel(null)).toEqual(LabelConstant.COLOR_WHITE.toLowerCase());
-  });
-});
-
-describe('LabelService: getLabelDefinition()', () => {
-  beforeEach(() => {
-    labelService = new LabelService(null);
-  });
-
-  afterEach(() => {
-    labelService = null;
-  });
-
-  it('should return the correct label definition for type.FunctionalityBug', () => {
-    expect(labelService.getLabelDefinition(LabelConstant.TYPE_FUNCTIONALITY_BUG, LabelConstant.TYPE)).toEqual(
-      LABEL_DEFINITIONS.typeFunctionalityBug
-    );
-  });
-
-  it('should return the correct label definition for severity.Medium', () => {
-    expect(labelService.getLabelDefinition(LabelConstant.SEVERITY_MEDIUM, LabelConstant.SEVERITY)).toEqual(
-      LABEL_DEFINITIONS.severityMedium
-    );
-  });
-
-  it('should return the correct label definition for response.Rejected', () => {
-    expect(labelService.getLabelDefinition(LabelConstant.RESPONSE_REJECTED, LabelConstant.RESPONSE)).toEqual(
-      LABEL_DEFINITIONS.responseRejected
-    );
-  });
-
-  it('should return null for label with no definition', () => {
-    expect(labelService.getLabelDefinition(LabelConstant.STATUS_DONE, LabelConstant.STATUS)).toEqual(LABEL_DEFINITIONS.undefined);
-  });
-
-  it('should return null for invalid inputs', () => {
-    expect(labelService.getLabelDefinition(null, null)).toEqual(LABEL_DEFINITIONS.undefined);
-    expect(labelService.getLabelDefinition(null, LabelConstant.SEVERITY)).toEqual(LABEL_DEFINITIONS.undefined);
-    expect(labelService.getLabelDefinition(LabelConstant.SEVERITY_MEDIUM, null)).toEqual(LABEL_DEFINITIONS.undefined);
-  });
-});
-
-function assertLabelCreated(githubService: any, label: Label) {
-  expect(githubService.createLabel).toHaveBeenCalledWith(label.getFormattedName(), label.labelColor);
-}
-
-function assertLabelNotCreated(githubService: any, label: Label) {
-  expect(githubService.createLabel).not.toHaveBeenCalledWith(label.getFormattedName(), label.labelColor);
-}

--- a/tests/services/label.service.spec.ts
+++ b/tests/services/label.service.spec.ts
@@ -1,9 +1,34 @@
+import { of } from 'rxjs';
 import { Label } from '../../src/app/core/models/label.model';
+import { GithubService } from '../../src/app/core/services/github.service';
 import { LabelService } from '../../src/app/core/services/label.service';
 import * as LabelConstant from '../constants/label.constants';
 
 let labelService: LabelService;
 let labelList: Label[];
+let githubServiceSpy: jasmine.SpyObj<GithubService>;
+
+describe('LabelService: fetchLabels()', () => {
+  beforeEach(() => {
+    githubServiceSpy = jasmine.createSpyObj('GithubService', ['fetchAllLabels']);
+    labelService = new LabelService(githubServiceSpy);
+  });
+
+  it('should fetch labels successfully', () => {
+    const mockLabels = LabelConstant.SEVERITY_LABELS;
+    const parsedLabels = labelService.parseLabelData(mockLabels);
+
+    githubServiceSpy.fetchAllLabels.and.returnValue(of(mockLabels));
+
+    labelService.fetchLabels().subscribe((response) => {
+      expect(response).toEqual(mockLabels);
+      expect(labelService.labels).toEqual(parsedLabels);
+      expect(labelService.simpleLabels).toEqual(parsedLabels);
+    });
+
+    expect(githubServiceSpy.fetchAllLabels).toHaveBeenCalled();
+  });
+});
 
 describe('LabelService: parseLabelData()', () => {
   beforeAll(() => {


### PR DESCRIPTION
### Summary:

Fixes part of #85 

#### Type of change:

- 🧪 Tests Update

### Changes Made:

- Refactor test cases for label service
- Add test case for `fetchLabels()`

### Proposed Commit Message:

```
Refactor test cases for label service

The test cases for the label service are outdated. 

Let's refactor the test cases for the label service and
add test case for fetchLabels method.
```