### PR TITLE
Refactor certain filters into its own service

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from 'src/app/shared/issue-tables/dropdownfilter';
+import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../../shared/issue-tables/dropdownfilter';
 
 @Injectable({
   providedIn: 'root'
@@ -8,44 +8,14 @@ import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from 'src/app/shared/issue-ta
 export class FiltersService {
   public dropdownFilter$ = new BehaviorSubject<DropdownFilter>(DEFAULT_DROPDOWN_FILTER);
 
-  addSelectedLabel(labelToAdd: string): void {
-    if (this.dropdownFilter$.value.labels.includes(labelToAdd)) {
-      return;
-    }
+  updateSelectedLabels(newSelectedLabels: string[]): void {
     this.dropdownFilter$.next({
       ...this.dropdownFilter$.value,
-      labels: [...this.dropdownFilter$.value.labels, labelToAdd]
+      labels: newSelectedLabels
     });
   }
 
-  removeSelectedLabel(labelToRemove: string): void {
-    if (!this.dropdownFilter$.value.labels.includes(labelToRemove)) {
-      return;
-    }
-    this.dropdownFilter$.next({
-      ...this.dropdownFilter$.value,
-      labels: this.dropdownFilter$.value.labels.filter((label) => label !== labelToRemove)
-    });
-  }
-
-  addHiddenLabel(labelToAdd: string): void {
-    if (this.dropdownFilter$.value.hiddenLabels.has(labelToAdd)) {
-      return;
-    }
-    const newHiddenLabels = new Set(this.dropdownFilter$.value.hiddenLabels);
-    newHiddenLabels.add(labelToAdd);
-    this.dropdownFilter$.next({
-      ...this.dropdownFilter$.value,
-      hiddenLabels: newHiddenLabels
-    });
-  }
-
-  removeHiddenLabel(labelToRemove: string): void {
-    if (!this.dropdownFilter$.value.hiddenLabels.has(labelToRemove)) {
-      return;
-    }
-    const newHiddenLabels = new Set(this.dropdownFilter$.value.hiddenLabels);
-    newHiddenLabels.delete(labelToRemove);
+  updateHiddenLabels(newHiddenLabels: Set<string>): void {
     this.dropdownFilter$.next({
       ...this.dropdownFilter$.value,
       hiddenLabels: newHiddenLabels

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, pipe } from 'rxjs';
 import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../../shared/issue-tables/dropdownfilter';
 
 @Injectable({
@@ -13,32 +13,21 @@ import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../../shared/issue-tabl
 export class FiltersService {
   public dropdownFilter$ = new BehaviorSubject<DropdownFilter>(DEFAULT_DROPDOWN_FILTER);
 
+  private _validateFilter = pipe(this.updateStatusPairing, this.updateTypePairing);
+
   clearFilters(): void {
     this.dropdownFilter$.next(DEFAULT_DROPDOWN_FILTER);
   }
 
-  updateSelectedLabels(newSelectedLabels: string[]): void {
-    this.dropdownFilter$.next({
+  updateFilters(newFilters: Partial<DropdownFilter>): void {
+    let nextDropdownFilter: DropdownFilter = {
       ...this.dropdownFilter$.value,
-      labels: newSelectedLabels
-    });
-  }
+      ...newFilters
+    };
 
-  updateHiddenLabels(newHiddenLabels: Set<string>): void {
-    this.dropdownFilter$.next({
-      ...this.dropdownFilter$.value,
-      hiddenLabels: newHiddenLabels
-    });
-  }
+    nextDropdownFilter = this._validateFilter(nextDropdownFilter);
 
-  updateStatus(newStatus: string): void {
-    const newDropdownFilter: DropdownFilter = { ...this.dropdownFilter$.value, status: newStatus };
-    this.dropdownFilter$.next(this.updateTypePairing(newDropdownFilter));
-  }
-
-  updateType(newType: string): void {
-    const newDropdownFilter: DropdownFilter = { ...this.dropdownFilter$.value, type: newType };
-    this.dropdownFilter$.next(this.updateStatusPairing(newDropdownFilter));
+    this.dropdownFilter$.next(nextDropdownFilter);
   }
 
   /**

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -31,6 +31,7 @@ export class FiltersService {
     const newDropdownFilter: DropdownFilter = { ...this.dropdownFilter$.value, type: newType };
     this.dropdownFilter$.next(this.updateStatusPairing(newDropdownFilter));
   }
+
   /**
    * Changes type to a valid, default value when an incompatible combination of type and status is encountered.
    */

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from 'src/app/shared/issue-tables/dropdownfilter';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FiltersService {
+  public dropdownFilter$ = new BehaviorSubject<DropdownFilter>(DEFAULT_DROPDOWN_FILTER);
+
+  addSelectedLabel(labelToAdd: string): void {
+    if (this.dropdownFilter$.value.labels.includes(labelToAdd)) {
+      return;
+    }
+    this.dropdownFilter$.next({
+      ...this.dropdownFilter$.value,
+      labels: [...this.dropdownFilter$.value.labels, labelToAdd]
+    });
+  }
+
+  removeSelectedLabel(labelToRemove: string): void {
+    if (!this.dropdownFilter$.value.labels.includes(labelToRemove)) {
+      return;
+    }
+    this.dropdownFilter$.next({
+      ...this.dropdownFilter$.value,
+      labels: this.dropdownFilter$.value.labels.filter((label) => label !== labelToRemove)
+    });
+  }
+
+  addHiddenLabel(labelToAdd: string): void {
+    if (this.dropdownFilter$.value.hiddenLabels.has(labelToAdd)) {
+      return;
+    }
+    const newHiddenLabels = new Set(this.dropdownFilter$.value.hiddenLabels);
+    newHiddenLabels.add(labelToAdd);
+    this.dropdownFilter$.next({
+      ...this.dropdownFilter$.value,
+      hiddenLabels: newHiddenLabels
+    });
+  }
+
+  removeHiddenLabel(labelToRemove: string): void {
+    if (!this.dropdownFilter$.value.hiddenLabels.has(labelToRemove)) {
+      return;
+    }
+    const newHiddenLabels = new Set(this.dropdownFilter$.value.hiddenLabels);
+    newHiddenLabels.delete(labelToRemove);
+    this.dropdownFilter$.next({
+      ...this.dropdownFilter$.value,
+      hiddenLabels: newHiddenLabels
+    });
+  }
+}

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -5,6 +5,11 @@ import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../../shared/issue-tabl
 @Injectable({
   providedIn: 'root'
 })
+
+/**
+ * Responsible for centralising filters
+ * Filters are subscribed to and emitted from this service
+ */
 export class FiltersService {
   public dropdownFilter$ = new BehaviorSubject<DropdownFilter>(DEFAULT_DROPDOWN_FILTER);
 

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -21,4 +21,33 @@ export class FiltersService {
       hiddenLabels: newHiddenLabels
     });
   }
+
+  updateStatus(newStatus: string): void {
+    const newDropdownFilter: DropdownFilter = { ...this.dropdownFilter$.value, status: newStatus };
+    this.dropdownFilter$.next(this.updateTypePairing(newDropdownFilter));
+  }
+
+  updateType(newType: string): void {
+    const newDropdownFilter: DropdownFilter = { ...this.dropdownFilter$.value, type: newType };
+    this.dropdownFilter$.next(this.updateStatusPairing(newDropdownFilter));
+  }
+  /**
+   * Changes type to a valid, default value when an incompatible combination of type and status is encountered.
+   */
+  updateTypePairing(dropdownFilter: DropdownFilter): DropdownFilter {
+    if (dropdownFilter.status === 'merged') {
+      dropdownFilter.type = 'pullrequest';
+    }
+    return dropdownFilter;
+  }
+
+  /**
+   * Changes status to a valid, default value when an incompatible combination of type and status is encountered.
+   */
+  updateStatusPairing(dropdownFilter: DropdownFilter): DropdownFilter {
+    if (dropdownFilter.status === 'merged' && dropdownFilter.type === 'issue') {
+      dropdownFilter.status = 'all';
+    }
+    return dropdownFilter;
+  }
 }

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -13,6 +13,10 @@ import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../../shared/issue-tabl
 export class FiltersService {
   public dropdownFilter$ = new BehaviorSubject<DropdownFilter>(DEFAULT_DROPDOWN_FILTER);
 
+  clearFilters(): void {
+    this.dropdownFilter$.next(DEFAULT_DROPDOWN_FILTER);
+  }
+
   updateSelectedLabels(newSelectedLabels: string[]): void {
     this.dropdownFilter$.next({
       ...this.dropdownFilter$.value,

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -9,7 +9,7 @@
     <div class="dropdown-filters">
       <mat-form-field appearance="standard">
         <mat-label>Status</mat-label>
-        <mat-select [(value)]="this.dropdownFilter.status" (selectionChange)="updateTypePairing(); applyDropdownFilter()">
+        <mat-select [(value)]="this.dropdownFilter.status" (selectionChange)="this.filtersService.updateStatus($event.value)">
           <mat-option value="all">All</mat-option>
           <mat-option value="open">Open</mat-option>
           <mat-option value="closed">Closed</mat-option>
@@ -18,7 +18,7 @@
       </mat-form-field>
       <mat-form-field appearance="standard">
         <mat-label>Type</mat-label>
-        <mat-select [(value)]="this.dropdownFilter.type" (selectionChange)="updateStatusPairing(); applyDropdownFilter()">
+        <mat-select [(value)]="this.dropdownFilter.type" (selectionChange)="this.filtersService.updateType($event.value)">
           <mat-option value="all">All</mat-option>
           <mat-option value="issue">Issue</mat-option>
           <mat-option value="pullrequest">Pull Request</mat-option>
@@ -59,6 +59,6 @@
   </mat-grid-tile>
 
   <mat-grid-tile class="label-filter-grid-tile" colspan="1">
-    <app-label-filter-bar [selectedLabels]="this.labelFilter$" [hiddenLabels]="this.hiddenLabels$"></app-label-filter-bar>
+    <app-label-filter-bar></app-label-filter-bar>
   </mat-grid-tile>
 </mat-grid-list>

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -9,7 +9,7 @@
     <div class="dropdown-filters">
       <mat-form-field appearance="standard">
         <mat-label>Status</mat-label>
-        <mat-select [(value)]="this.dropdownFilter.status" (selectionChange)="this.filtersService.updateStatus($event.value)">
+        <mat-select [value]="this.dropdownFilter.status" (selectionChange)="this.filtersService.updateStatus($event.value)">
           <mat-option value="all">All</mat-option>
           <mat-option value="open">Open</mat-option>
           <mat-option value="closed">Closed</mat-option>
@@ -18,7 +18,7 @@
       </mat-form-field>
       <mat-form-field appearance="standard">
         <mat-label>Type</mat-label>
-        <mat-select [(value)]="this.dropdownFilter.type" (selectionChange)="this.filtersService.updateType($event.value)">
+        <mat-select [value]="this.dropdownFilter.type" (selectionChange)="this.filtersService.updateType($event.value)">
           <mat-option value="all">All</mat-option>
           <mat-option value="issue">Issue</mat-option>
           <mat-option value="pullrequest">Pull Request</mat-option>

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -9,7 +9,7 @@
     <div class="dropdown-filters">
       <mat-form-field appearance="standard">
         <mat-label>Status</mat-label>
-        <mat-select [value]="this.dropdownFilter.status" (selectionChange)="this.filtersService.updateStatus($event.value)">
+        <mat-select [value]="this.dropdownFilter.status" (selectionChange)="this.filtersService.updateFilters({ status: $event.value })">
           <mat-option value="all">All</mat-option>
           <mat-option value="open">Open</mat-option>
           <mat-option value="closed">Closed</mat-option>
@@ -18,7 +18,7 @@
       </mat-form-field>
       <mat-form-field appearance="standard">
         <mat-label>Type</mat-label>
-        <mat-select [value]="this.dropdownFilter.type" (selectionChange)="this.filtersService.updateType($event.value)">
+        <mat-select [value]="this.dropdownFilter.type" (selectionChange)="this.filtersService.updateFilters({ type: $event.value })">
           <mat-option value="all">All</mat-option>
           <mat-option value="issue">Issue</mat-option>
           <mat-option value="pullrequest">Pull Request</mat-option>

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -47,9 +47,9 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   constructor(
     public milestoneService: MilestoneService,
+    public filtersService: FiltersService,
     private phaseService: PhaseService,
-    private logger: LoggingService,
-    private filtersService: FiltersService
+    private logger: LoggingService
   ) {
     this.repoChangeSubscription = this.phaseService.repoChanged$.subscribe((newRepo) => this.initialize());
   }
@@ -78,24 +78,6 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   applyFilter(filterValue: string) {
     this.views$?.value?.forEach((v) => (v.retrieveFilterable().filter = filterValue));
-  }
-
-  /**
-   * Changes type to a valid, default value when an incompatible combination of type and status is encountered.
-   */
-  updateTypePairing() {
-    if (this.dropdownFilter.status === 'merged') {
-      this.dropdownFilter.type = 'pullrequest';
-    }
-  }
-
-  /**
-   * Changes status to a valid, default value when an incompatible combination of type and status is encountered.
-   */
-  updateStatusPairing() {
-    if (this.dropdownFilter.status === 'merged' && this.dropdownFilter.type === 'issue') {
-      this.dropdownFilter.status = 'all';
-    }
   }
 
   /**

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { LoggingService } from '../../core/services/logging.service';
 import { MilestoneService } from '../../core/services/milestone.service';
 import { PhaseService } from '../../core/services/phase.service';
+import { FiltersService } from '../../core/services/filters.service';
 import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../issue-tables/dropdownfilter';
 import { FilterableComponent } from '../issue-tables/filterableTypes';
 import { LabelFilterBarComponent } from './label-filter-bar/label-filter-bar.component';
@@ -44,7 +45,12 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @ViewChild('milestoneSelectorRef', { static: false }) milestoneSelectorRef: MatSelect;
 
-  constructor(public milestoneService: MilestoneService, private phaseService: PhaseService, private logger: LoggingService) {
+  constructor(
+    public milestoneService: MilestoneService,
+    private phaseService: PhaseService,
+    private logger: LoggingService,
+    private filtersService: FiltersService
+  ) {
     this.repoChangeSubscription = this.phaseService.repoChanged$.subscribe((newRepo) => this.initialize());
   }
 
@@ -53,14 +59,8 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    /** Apply dropdown filter when LabelChipBar populates with label filters */
-    this.labelFilterSubscription = this.labelFilter$.subscribe((labels) => {
-      this.dropdownFilter.labels = labels;
-      this.applyDropdownFilter();
-    });
-
-    this.hiddenLabelSubscription = this.hiddenLabels$.subscribe((labels) => {
-      this.dropdownFilter.hiddenLabels = labels;
+    this.filtersService.dropdownFilter$.subscribe((dropdownFilter) => {
+      this.dropdownFilter = dropdownFilter;
       this.applyDropdownFilter();
     });
   }

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -2,10 +2,10 @@ import { AfterViewInit, Component, Input, OnDestroy, OnInit, QueryList, ViewChil
 import { MatSelect } from '@angular/material/select';
 import { MatSort } from '@angular/material/sort';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import { FiltersService } from '../../core/services/filters.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { MilestoneService } from '../../core/services/milestone.service';
 import { PhaseService } from '../../core/services/phase.service';
-import { FiltersService } from '../../core/services/filters.service';
 import { DEFAULT_DROPDOWN_FILTER, DropdownFilter } from '../issue-tables/dropdownfilter';
 import { FilterableComponent } from '../issue-tables/filterableTypes';
 import { LabelFilterBarComponent } from './label-filter-bar/label-filter-bar.component';

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -48,7 +48,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     this.hiddenLabelNames.add(label);
-    this.filtersService.updateHiddenLabels(this.hiddenLabelNames);
+    this.filtersService.updateFilters({ hiddenLabels: this.hiddenLabelNames });
   }
 
   /** Show labels that were hidden */
@@ -57,7 +57,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       return;
     }
     this.hiddenLabelNames.delete(label);
-    this.filtersService.updateHiddenLabels(this.hiddenLabelNames);
+    this.filtersService.updateFilters({ hiddenLabels: this.hiddenLabelNames });
   }
 
   /**
@@ -99,7 +99,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   }
 
   updateSelection(): void {
-    this.filtersService.updateSelectedLabels(this.selectedLabelNames);
+    this.filtersService.updateFilters({ labels: this.selectedLabelNames });
   }
 
   removeAllSelection(): void {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { SimpleLabel } from '../../../core/models/label.model';
 import { LabelService } from '../../../core/services/label.service';
 import { LoggingService } from '../../../core/services/logging.service';
+import { FiltersService } from '../../../core/services/filters.service';
 
 @Component({
   selector: 'app-label-filter-bar',
@@ -11,8 +12,6 @@ import { LoggingService } from '../../../core/services/logging.service';
   styleUrls: ['./label-filter-bar.component.css']
 })
 export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
-  @Input() selectedLabels: BehaviorSubject<string[]>;
-  @Input() hiddenLabels: BehaviorSubject<Set<string>>;
   @ViewChild(MatSelectionList) matSelectionList;
 
   labels$: Observable<SimpleLabel[]>;
@@ -23,7 +22,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
 
   labelSubscription: Subscription;
 
-  constructor(private labelService: LabelService, private logger: LoggingService) {}
+  constructor(private labelService: LabelService, private logger: LoggingService, private filtersService: FiltersService) {}
 
   ngOnInit() {
     this.loaded = false;
@@ -49,7 +48,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     this.hiddenLabelNames.add(label);
-    this.hiddenLabels.next(this.hiddenLabelNames);
+    this.filtersService.updateHiddenLabels(this.hiddenLabelNames);
   }
 
   /** Show labels that were hidden */
@@ -58,7 +57,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       return;
     }
     this.hiddenLabelNames.delete(label);
-    this.hiddenLabels.next(this.hiddenLabelNames);
+    this.filtersService.updateHiddenLabels(this.hiddenLabelNames);
   }
 
   /**
@@ -71,7 +70,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       return;
     }
     el.toggle();
-    this.selectedLabels.next(this.selectedLabelNames);
+    this.updateSelection();
   }
 
   /** loads in the labels in the repository */
@@ -100,7 +99,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   }
 
   updateSelection(): void {
-    this.selectedLabels.next(this.selectedLabelNames);
+    this.filtersService.updateSelectedLabels(this.selectedLabelNames);
   }
 
   removeAllSelection(): void {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -2,9 +2,9 @@ import { AfterViewInit, Component, Input, OnDestroy, OnInit, ViewChild } from '@
 import { MatListOption, MatSelectionList } from '@angular/material/list';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { SimpleLabel } from '../../../core/models/label.model';
+import { FiltersService } from '../../../core/services/filters.service';
 import { LabelService } from '../../../core/services/label.service';
 import { LoggingService } from '../../../core/services/logging.service';
-import { FiltersService } from '../../../core/services/filters.service';
 
 @Component({
   selector: 'app-label-filter-bar',

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -10,6 +10,7 @@ import { Repo } from '../../core/models/repo.model';
 import { AuthService } from '../../core/services/auth.service';
 import { DialogService } from '../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
+import { FiltersService } from '../../core/services/filters.service';
 import { GithubService } from '../../core/services/github.service';
 import { GithubEventService } from '../../core/services/githubevent.service';
 import { IssueService } from '../../core/services/issue.service';
@@ -58,7 +59,8 @@ export class HeaderComponent implements OnInit {
     private errorHandlingService: ErrorHandlingService,
     private githubService: GithubService,
     private dialogService: DialogService,
-    private repoSessionStorageService: RepoSessionStorageService
+    private repoSessionStorageService: RepoSessionStorageService,
+    private filtersService: FiltersService
   ) {
     router.events
       .pipe(
@@ -227,6 +229,9 @@ export class HeaderComponent implements OnInit {
     if (newRepoString === this.currentRepo) {
       return;
     }
+
+    this.filtersService.clearFilters();
+
     this.phaseService
       .changeRepositoryIfValid(repo)
       .then(() => {


### PR DESCRIPTION
### Summary:

Fixes part of #249 

#### Type of change:

- 🎨 Code Refactoring

### Changes Made:

* Refactored a few filters into their own service
* Does not break any behaviour for other filters
* Other filters will be refactored in another PR to reduce the size of this one
* Refactored following filters
  * Selected labels
  * Hidden labels
  * Status
  * Type

### Proposed Commit Message:

```
Filters are observed, subscribed and emitted in many different 
components.

This makes the code base hard to understand
and adapt for filtering in future components.

Let's refactor the filters into its own centralised service
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
