### PR TITLE
Fix zone testing import error

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -1,8 +1,7 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
-
+import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,5 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+// tslint:disable:ordered-imports
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,8 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
 // tslint:disable:ordered-imports
+// Ordered-imports rule is disabled here because the import statement for 'zone-testing' must be
+// at the top to prevent test setup breakage in 'npm run test'.
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';


### PR DESCRIPTION
### Summary:

Fixes #268 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Move import statement of `zone.js/dist/zone-testing` to the top of `test.ts` file
- Disable tslint rule on ordered-imports for `test.ts` file

### Proposed Commit Message:

```
Fix zone-testing import error

Npm run test will break if the import statement 
for zone-testing is not at the top of test.ts file. 

Let's reorder the import statement and disable
tslint rule for test.ts file.
```
