### PR TITLE
Three-state labels

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -10,6 +10,7 @@ export type Filter = {
   labels: string[];
   milestones: string[];
   hiddenLabels?: Set<string>;
+  deselectedLabels: Set<string>;
 };
 
 export const DEFAULT_FILTER: Filter = {
@@ -18,7 +19,8 @@ export const DEFAULT_FILTER: Filter = {
   type: 'all',
   sort: { active: 'id', direction: 'asc' },
   labels: [],
-  milestones: []
+  milestones: [],
+  deselectedLabels: new Set<string>()
 };
 
 @Injectable({

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
@@ -88,12 +88,26 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  width: calc(100% - 8px);
   border-radius: 10px;
   height: 40px;
   padding: 0px 12px;
   margin: 8px 4px;
   box-sizing: border-box;
+  position: relative;
+}
+
+.flexbox-container:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.flexbox-container-strikethrough {
+  position: absolute;
+  top: 50%;
+  width: 90%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: 2px;
+  background-color: black;
 }
 
 .input-field {
@@ -111,7 +125,6 @@
   min-height: 16px;
   max-height: 42px;
   margin: 0px;
-  top: 50%;
 }
 
 .mat-stroked-button {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.css
@@ -88,15 +88,17 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
+  width: calc(100% - 8px);
+  border-radius: 10px;
+  height: 40px;
+  padding: 0px 12px;
+  margin: 8px 4px;
+  box-sizing: border-box;
 }
 
 .input-field {
   width: calc(100% - (2 * 15px)); /* To account for left and right padding. */
   padding: 0 15px;
-}
-
-.list-option {
-  width: 100%;
 }
 
 .mat-chip {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -1,5 +1,5 @@
 <button mat-stroked-button *ngIf="loaded" [matMenuTriggerFor]="menu">
-  {{ selectedLabelNames.length == 0 ? 'All' : selectedLabelNames.length }} Selected | {{ hiddenLabelNames?.size || 0 }} Hidden ▾
+  {{ selectedLabelNames.size === 0 ? 'All' : selectedLabelNames.size }} Selected | {{ hiddenLabelNames?.size || 0 }} Hidden ▾
 </button>
 
 <button mat-stroked-button disabled *ngIf="!loaded" color="accent">
@@ -19,32 +19,27 @@
 
     <div class="scroll-container-wrapper">
       <div class="scroll-container">
-        <mat-selection-list [(ngModel)]="selectedLabelNames" (selectionChange)="updateSelection()">
-          <mat-list-option
-            #option
-            *ngFor="let label of this.labels$ | async"
-            [value]="label.name"
-            [selected]="selectedLabelNames.includes(label.name)"
-            class="list-option"
-            [class.hidden]="filter(input.value, label.name)"
+        <div
+          *ngFor="let label of this.allLabels"
+          class="flexbox-container"
+          (click)="changeLabelState(label)"
+          [class.hidden]="filter(input.value, label.name)"
+          [style]="{ border: '2px solid ' + getBorderColor(label) }"
+        >
+          <button mat-icon-button *ngIf="!hiddenLabelNames.has(label.name)" (click)="hide(label.name); $event.stopPropagation()">
+            <mat-icon>visibility</mat-icon>
+          </button>
+          <button mat-icon-button *ngIf="hiddenLabelNames.has(label.name)" (click)="show(label.name); $event.stopPropagation()">
+            <mat-icon>visibility_off</mat-icon>
+          </button>
+          <mat-chip
+            [ngStyle]="labelService.setLabelStyle(label.color)"
+            [disabled]="hiddenLabelNames.has(label.name)"
+            (click)="changeLabelState(label)"
           >
-            <div class="flexbox-container">
-              <button mat-icon-button *ngIf="!hiddenLabelNames.has(label.name)" (click)="hide(label.name); $event.stopPropagation()">
-                <mat-icon>visibility</mat-icon>
-              </button>
-              <button mat-icon-button *ngIf="hiddenLabelNames.has(label.name)" (click)="show(label.name); $event.stopPropagation()">
-                <mat-icon>visibility_off</mat-icon>
-              </button>
-              <mat-chip
-                [ngStyle]="labelService.setLabelStyle(label.color)"
-                [disabled]="hiddenLabelNames.has(label.name)"
-                (click)="simulateClick(option); $event.stopPropagation()"
-              >
-                {{ label.name }}
-              </mat-chip>
-            </div>
-          </mat-list-option>
-        </mat-selection-list>
+            {{ label.name }}
+          </mat-chip>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -24,7 +24,7 @@
           class="flexbox-container"
           (click)="changeLabelState(label)"
           [class.hidden]="filter(input.value, label.name)"
-          [style]="{ border: '2px solid ' + getBorderColor(label) }"
+          [style]="{ border: '2px solid ' + getColor(label) }"
         >
           <button mat-icon-button *ngIf="!hiddenLabelNames.has(label.name)" (click)="hide(label.name); $event.stopPropagation()">
             <mat-icon>visibility</mat-icon>
@@ -39,6 +39,7 @@
           >
             {{ label.name }}
           </mat-chip>
+          <div *ngIf="deselectedLabelNames.has(label.name)" class="flexbox-container-strikethrough"></div>
         </div>
       </div>
     </div>

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -1,5 +1,4 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { MatSelectionList } from '@angular/material/list';
 import { Observable, Subscription } from 'rxjs';
 import { SimpleLabel } from '../../../core/models/label.model';
 import { FiltersService } from '../../../core/services/filters.service';
@@ -12,8 +11,6 @@ import { LoggingService } from '../../../core/services/logging.service';
   styleUrls: ['./label-filter-bar.component.css']
 })
 export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
-  @ViewChild(MatSelectionList) matSelectionList;
-
   labels$: Observable<SimpleLabel[]>;
   allLabels: SimpleLabel[];
   selectedLabelNames: Set<string> = new Set<string>();
@@ -129,7 +126,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   }
 
   removeAllSelection(): void {
-    this.matSelectionList.deselectAll();
+    this.selectedLabelNames = new Set<string>();
+    this.deselectedLabelNames = new Set<string>();
     this.updateSelection();
   }
 }

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatSelectionList } from '@angular/material/list';
 import { Observable, Subscription } from 'rxjs';
-import { SimpleLabel, Label } from '../../../core/models/label.model';
+import { SimpleLabel } from '../../../core/models/label.model';
 import { FiltersService } from '../../../core/services/filters.service';
 import { LabelService } from '../../../core/services/label.service';
 import { LoggingService } from '../../../core/services/logging.service';

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -11,6 +11,10 @@ import { LoggingService } from '../../../core/services/logging.service';
   styleUrls: ['./label-filter-bar.component.css']
 })
 export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
+  private static readonly DEFAULT_LABEL_COLOR: string = 'transparent';
+  private static readonly DESELECTED_LABEL_COLOR: string = '#b00020';
+  private static readonly SELECTED_LABEL_COLOR: string = '#41c300';
+
   labels$: Observable<SimpleLabel[]>;
   allLabels: SimpleLabel[];
   selectedLabelNames: Set<string> = new Set<string>();
@@ -19,10 +23,6 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   loaded = false;
 
   labelSubscription: Subscription;
-
-  private static readonly SELECTED_LABEL_COLOR: string = '#41c300';
-  private static readonly DESELECTED_LABEL_COLOR: string = '#b00020';
-  private static readonly DEFAULT_LABEL_COLOR: string = 'transparent';
 
   constructor(private labelService: LabelService, private logger: LoggingService, private filtersService: FiltersService) {}
 

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -23,6 +23,10 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
 
   labelSubscription: Subscription;
 
+  private static readonly SELECTED_LABEL_COLOR: string = '#41c300';
+  private static readonly DESELECTED_LABEL_COLOR: string = '#b00020';
+  private static readonly DEFAULT_LABEL_COLOR: string = 'transparent';
+
   constructor(private labelService: LabelService, private logger: LoggingService, private filtersService: FiltersService) {}
 
   ngOnInit() {
@@ -82,13 +86,13 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
    * Returns the border color of the label.
    * The border color represents the state of the label.
    */
-  getBorderColor(label: SimpleLabel): string {
+  getColor(label: SimpleLabel): string {
     if (this.selectedLabelNames.has(label.name)) {
-      return '#2bfc2e';
+      return LabelFilterBarComponent.SELECTED_LABEL_COLOR;
     } else if (this.deselectedLabelNames.has(label.name)) {
-      return '#ff0303';
+      return LabelFilterBarComponent.DESELECTED_LABEL_COLOR;
     } else {
-      return 'transparent';
+      return LabelFilterBarComponent.DEFAULT_LABEL_COLOR;
     }
   }
 

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -26,7 +26,7 @@ export function applyDropdownFilter(filter: Filter, data: Issue[]): Issue[] {
       ret = ret && issue.issueOrPr === 'PullRequest';
     }
 
-    ret = ret && filter.milestones.some((milestone) => issue.milestone.number === milestone);
+    ret = ret && filter.milestones.some((milestone) => issue.milestone.title === milestone);
     ret = ret && issue.labels.every((label) => !filter.deselectedLabels.has(label));
     return ret && filter.labels.every((label) => issue.labels.includes(label));
   });

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -27,7 +27,7 @@ export function applyDropdownFilter(filter: Filter, data: Issue[]): Issue[] {
     }
 
     ret = ret && filter.milestones.some((milestone) => issue.milestone.number === milestone);
-
+    ret = ret && issue.labels.every((label) => !filter.deselectedLabels.has(label));
     return ret && filter.labels.every((label) => issue.labels.includes(label));
   });
   return filteredData;

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -118,23 +118,19 @@ describe('LabelFilterBarComponent', () => {
   describe('updateSelection', () => {
     it('should update filters service with selected labels', () => {
       const selectedLabels = [LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW];
-      component.selectedLabelNames = selectedLabels;
+      component.selectedLabelNames = new Set<string>(selectedLabels);
 
       component.updateSelection();
 
-      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ labels: selectedLabels });
+      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ labels: selectedLabels, deselectedLabels: new Set<string>() });
     });
   });
 
   describe('removeAllSelection', () => {
     it('should deselect all labels and update the filter', () => {
-      const matSelectionListSpy = jasmine.createSpyObj<MatSelectionList>('MatSelectionList', ['deselectAll']);
-      component.matSelectionList = matSelectionListSpy;
-
       component.removeAllSelection();
-
-      expect(matSelectionListSpy.deselectAll).toHaveBeenCalled();
-      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ labels: [] });
+      expect(component.selectedLabelNames).toEqual(new Set<string>());
+      expect(component.deselectedLabelNames).toEqual(new Set<string>());
     });
   });
 });

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -121,7 +121,7 @@ describe('LabelFilterBarComponent', () => {
       const selectedLabels = [LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW];
       component.selectedLabelNames = new Set<string>(selectedLabels);
 
-      component.updateSelection([]);
+      component.updateSelection();
 
       expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ labels: selectedLabels, deselectedLabels: new Set<string>() });
     });


### PR DESCRIPTION
### Summary:

Fixes part of #240.

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

Made the filter labels a three-state button.

Each filter label has the following 3 possible states:
* Default: no filter applied. This corresponds to no border.
* Selected: filter **in** all issues/PRs with this label. This corresponds to green border.
* Deselected: filter **out** all issues/PRs with this label. This corresponds to red border.

Additionally, each label has the following state rotation: default -> selected -> deselected.

The old checkbox for two-state is removed. Labels are manually added to the set of selected/deselected label names.

Finally, the set of deselected label names are used in the filter to apply them to the issues/PRs displayed.

There is one case that I need to highlight. That is, if an issue/PR has 2 labels, one is in selected state, and one is in deselected state. Currently, the filter with deselected state takes precedence, so an issue/PR with deselected labels will be filtered out, regardless of whether any other of its labels are being selected. Consider #251 with labels `category.Feature` and `category.Enhancement`, currently being assigned to me:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/78453e0f-8907-4f78-a2ef-70c358a902ff)

It is being filtered out.

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/74250a2e-eda4-47cb-9825-f053831a7a19)

![image](https://github.com/CATcher-org/WATcher/assets/87511888/8d04ee8d-373b-4ba5-aab4-c8c573d11691)

### Proposed Commit Message:

```
Three-state labels

Previously, each label only has 2 states, either selected or
not selected. However, with such design,
the feature of hiding labels can be confused
with hiding issues/PRs with the label.

We implement the three-state label filters,
so that each label can also be used to hide
issues/PRs with the label.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
