### PR TITLE
Enable pre push hook for npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",
-      "pre-push": "npm run lint"
+      "pre-push": "npm run lint && npm run test"
     }
   },
   "dependencies": {


### PR DESCRIPTION
### Summary:

Fixes #87

#### Type of change:

- 🧪 Tests Update

### Proposed Commit Message:

```
Enable pre-push hook for npm test execution

pre-push hook that runs `npm run test` automatically 
ensures all tests pass locally, enhancing code quality 
and preventing the accidental push of failing code.

Let's enable the pre-push hook.
```
