### PR TITLE
Refactor milestones to save by name

### DIFF
--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -2,18 +2,16 @@
  * Represents a milestone and its attributes fetched from Github.
  */
 export class Milestone {
-  static DefaultMilestone: Milestone = new Milestone({ number: 'untracked', title: 'Without a milestone', state: null });
-  readonly number: string; // equivalent to the id of an issue e.g. milestone #1
+  static DefaultMilestone: Milestone = new Milestone({ title: 'Without a milestone', state: null });
   title: string;
   state: string;
 
-  constructor(milestone: { number: string; title: string; state: string }) {
-    this.number = milestone.number;
+  constructor(milestone: { title: string; state: string }) {
     this.title = milestone.title;
     this.state = milestone.state;
   }
 
   public equals(milestone: Milestone) {
-    return this.number === milestone.number;
+    return this.title === milestone.title;
   }
 }

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -55,7 +55,7 @@
           <mat-select-trigger *ngIf="this.milestoneService.hasNoMilestones">
             <span>No Milestones</span>
           </mat-select-trigger>
-          <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.number">
+          <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.title">
             {{ milestone.title }}
           </mat-option>
         </mat-select>

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -79,7 +79,7 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
     this.milestoneSubscription = this.milestoneService.fetchMilestones().subscribe(
       (response) => {
         this.logger.debug('IssuesViewerComponent: Fetched milestones from Github');
-        this.milestoneService.milestones.forEach((milestone) => this.filter.milestones.push(milestone.number));
+        this.milestoneService.milestones.forEach((milestone) => this.filter.milestones.push(milestone.title));
       },
       (err) => {},
       () => {}

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -26,7 +26,7 @@ export function applyDropdownFilter(filter: Filter, data: Issue[]): Issue[] {
       ret = ret && issue.issueOrPr === 'PullRequest';
     }
 
-    ret = ret && filter.milestones.some((milestone) => issue.milestone.number === milestone);
+    ret = ret && filter.milestones.some((milestone) => issue.milestone.title === milestone);
 
     return ret && filter.labels.every((label) => issue.labels.includes(label));
   });


### PR DESCRIPTION
### Summary:

Fixes #283 

#### Type of change:

- 🎨 Code Refactoring

### Changes Made:

- Change milestone saving behavior to use title of milestone instead of number
- Remove now redundant number property in milestone model

### Proposed Commit Message:

```
We store milestones by number.

This works when filters are confined to one repo, but
doesn't make sense when saving filters across repos.

Let's refactor the milestones to save by title instead
of number
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
