### PR TITLE
Setup grouping strategy and service

### DIFF
--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -1,4 +1,9 @@
-export interface GithubUser {
+import { Group } from './github/group.interface';
+
+/**
+ * Represents raw data returned from the GitHub API about a user.
+ */
+export interface RawGithubUser {
   avatar_url: string;
   created_at: string;
   html_url: string;
@@ -10,4 +15,46 @@ export interface GithubUser {
   type: string;
   updated_at: string;
   url: string;
+}
+
+/**
+ * Represents a GitHub user in WATcher
+ */
+export class GithubUser implements RawGithubUser, Group {
+  static NO_ASSIGNEE: GithubUser = new GithubUser({
+    avatar_url: '',
+    created_at: '',
+    html_url: '',
+    login: 'Unassigned',
+    name: '',
+    node_id: '',
+    two_factor_authentication: false,
+    site_admin: false,
+    type: '',
+    updated_at: '',
+    url: ''
+  });
+
+  avatar_url: string;
+  created_at: string;
+  html_url: string;
+  login: string;
+  name: string;
+  node_id: string;
+  two_factor_authentication: boolean;
+  site_admin: false;
+  type: string;
+  updated_at: string;
+  url: string;
+
+  constructor(rawData: RawGithubUser) {
+    Object.assign(this, rawData);
+  }
+
+  equals(other: any) {
+    if (!(other instanceof GithubUser)) {
+      return false;
+    }
+    return this.login === other.login;
+  }
 }

--- a/src/app/core/models/github/group.interface.ts
+++ b/src/app/core/models/github/group.interface.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents a group used for grouping purposes.
+ * Groups can be used to organize issues/prs based on certain criteria,
+ * such as milestones, assignees, or other properties.
+ */
+export interface Group {
+  equals(other: any): boolean;
+}

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../graphql/graphql-types';
 import { AppConfig } from '../../../environments/environment';
 import { getNumberOfPages } from '../../shared/lib/github-paginator-parser';
-import { GithubUser } from '../models/github-user.model';
+import { GithubUser, RawGithubUser } from '../models/github-user.model';
 import { IssueLastModifiedManagerModel } from '../models/github/cache-manager/issue-last-modified-manager.model';
 import { IssuesCacheManager } from '../models/github/cache-manager/issues-cache-manager.model';
 import { GithubEvent } from '../models/github/github-event.model';
@@ -314,7 +314,10 @@ export class GithubService {
       })
     ).pipe(
       map((response) => {
-        return response['data'];
+        const data: RawGithubUser[] = response['data'];
+        return data.map((rawGithubUser) => {
+          return new GithubUser(rawGithubUser);
+        });
       }),
       catchError((err) => throwError(ErrorMessageService.unableToFetchUsersMessage()))
     );
@@ -406,7 +409,8 @@ export class GithubService {
   fetchAuthenticatedUser(): Observable<GithubUser> {
     return from(octokit.users.getAuthenticated()).pipe(
       map((response) => {
-        return response['data'];
+        const data: RawGithubUser = response['data'];
+        return new GithubUser(data);
       }),
       catchError((err) => throwError(ErrorMessageService.unableToFetchAuthenticatedUsersMessage()))
     );

--- a/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { GithubUser } from '../../models/github-user.model';
+import { Issue } from '../../models/issue.model';
+import { GithubService } from '../github.service';
+import { GroupingStrategy } from './grouping-strategy.interface';
+
+/**
+ * A GroupingStrategy that groups issues/prs based on their assignees.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class AssigneeGroupingStrategy implements GroupingStrategy {
+  constructor(private githubService: GithubService) {}
+
+  /**
+   * Retrieves data for a specific assignee.
+   * If it is the"No Assignee" group, unassigned issues are returned.
+   * Otherwise, issues assigned to the specified user are returned.
+   */
+  getDataForGroup(issues: Issue[], key: GithubUser): Issue[] {
+    if (key === GithubUser.NO_ASSIGNEE) {
+      return this.getUnassignedData(issues);
+    }
+
+    return this.getDataAssignedToUser(issues, key);
+  }
+
+  /**
+   * Retrieves an Observable emitting users who can be assigned to issues,
+   * including a special "No Assignee" option.
+   */
+  getGroups(): Observable<GithubUser[]> {
+    return this.githubService.getUsersAssignable().pipe(
+      map((users) => {
+        users.push(GithubUser.NO_ASSIGNEE);
+        return users;
+      })
+    );
+  }
+
+  /**
+   * Groups other than "No Assignee" need to be shown on the
+   * hidden group list if empty.
+   */
+  isInHiddenList(group: GithubUser): boolean {
+    return group !== GithubUser.NO_ASSIGNEE;
+  }
+
+  private getDataAssignedToUser(issues: Issue[], user: GithubUser): Issue[] {
+    const filteredIssues = issues.filter((issue) => {
+      if (this.isPullRequest(issue)) {
+        return this.isPullRequestCreatedByTarget(issue, user);
+      }
+
+      return this.isIssueAssignedToTarget(issue, user);
+    });
+
+    return filteredIssues;
+  }
+
+  private getUnassignedData(issues: Issue[]): Issue[] {
+    return issues.filter((issue) => !this.isPullRequest(issue) && issue.assignees.length === 0);
+  }
+
+  private isPullRequest(issue: Issue): boolean {
+    return issue.issueOrPr === 'PullRequest';
+  }
+
+  private isPullRequestCreatedByTarget(issue: Issue, target: GithubUser): boolean {
+    return issue.author === target.login;
+  }
+
+  private isIssueAssignedToTarget(issue: Issue, target: GithubUser): boolean {
+    const isAssigneesFieldDefined = !!issue.assignees;
+
+    return isAssigneesFieldDefined && issue.assignees.includes(target.login);
+  }
+}

--- a/src/app/core/services/grouping/grouping-context.service.ts
+++ b/src/app/core/services/grouping/grouping-context.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Injector } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Group } from '../../models/github/group.interface';
+import { Issue } from '../../models/issue.model';
+import { AssigneeGroupingStrategy } from './assignee-grouping-strategy.service';
+import { GroupingStrategy } from './grouping-strategy.interface';
+
+export enum GroupBy {
+  Assignee = 'assignee',
+  Milestone = 'milestone'
+}
+
+export const DEFAULT_GROUPBY = GroupBy.Assignee;
+
+/**
+ * A service responsible for managing the current grouping strategy and providing grouped data.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class GroupingContextService {
+  private currGroupBySubject: BehaviorSubject<GroupBy>;
+  currGroupBy: GroupBy;
+  currGroupBy$: Observable<GroupBy>;
+
+  private groupingStrategyMap: Map<string, GroupingStrategy>;
+
+  constructor(private injector: Injector) {
+    this.currGroupBy = DEFAULT_GROUPBY;
+    this.currGroupBySubject = new BehaviorSubject<GroupBy>(this.currGroupBy);
+    this.currGroupBy$ = this.currGroupBySubject.asObservable();
+
+    this.groupingStrategyMap = new Map<string, GroupingStrategy>();
+
+    // Initialize the grouping strategy map with available strategies
+    this.groupingStrategyMap.set(GroupBy.Assignee, this.injector.get(AssigneeGroupingStrategy));
+  }
+
+  /**
+   * Sets the current grouping type.
+   * @param groupBy - The grouping type to set.
+   */
+  setCurrentGroupingType(groupBy: GroupBy): void {
+    this.currGroupBy = groupBy;
+    this.currGroupBySubject.next(this.currGroupBy);
+  }
+
+  /**
+   * Retrieves data for a specific group.
+   * @param issues - An array of issues to be grouped.
+   * @param group - The group by which issues are to be grouped.
+   * @returns An array of issues belonging to the specified group.
+   */
+  getDataForGroup(issues: Issue[], group: Group): Issue[] {
+    const strategy = this.groupingStrategyMap.get(this.currGroupBy);
+    return strategy.getDataForGroup(issues, group);
+  }
+
+  /**
+   * Retrieves all groups available for current grouping strategy.
+   * @returns An Observable emitting an array of groups.
+   */
+  getGroups(): Observable<Group[]> {
+    const strategy = this.groupingStrategyMap.get(this.currGroupBy);
+    return strategy.getGroups();
+  }
+
+  /**
+   * Determines whether a group should be shown on hidden list if it contains no issues.
+   * @param group - The group to check.
+   * @returns A boolean indicating whether the group should be shown on hidden list if empty.
+   */
+  isInHiddenList(group: Group): boolean {
+    const strategy = this.groupingStrategyMap.get(this.currGroupBy);
+    return strategy.isInHiddenList(group);
+  }
+
+  /**
+   * Resets the current grouping type to the default.
+   */
+  reset(): void {
+    this.setCurrentGroupingType(DEFAULT_GROUPBY);
+  }
+}

--- a/src/app/core/services/grouping/grouping-strategy.interface.ts
+++ b/src/app/core/services/grouping/grouping-strategy.interface.ts
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs';
+import { Group } from '../../models/github/group.interface';
+import { Issue } from '../../models/issue.model';
+
+/**
+ * Represent a strategy for grouping issues/prs.
+ * This interface follows the Strategy Pattern, allowing for different
+ * strategies to be implemented for grouping issues/prs based on different criteria.
+ */
+export interface GroupingStrategy {
+  /**
+   * Retrieves data for a specific group.
+   * @param issues - An array of issues to be grouped.
+   * @param key - The group by which issues are to be grouped.
+   * @returns An array of issues belonging to the specified group.
+   */
+  getDataForGroup(issues: Issue[], key: Group): Issue[];
+
+  /**
+   * Retrieves observable emitting groups available for the grouping strategy.
+   * @returns An Observable emitting an array of groups.
+   */
+  getGroups(): Observable<Group[]>;
+
+  /**
+   * Determines whether a group should be shown on hidden list if it contains no issues.
+   * @param group - The group to check.
+   * @returns A boolean indicating whether the group should be shown on hidden list if empty.
+   */
+  isInHiddenList(group: Group): boolean;
+}


### PR DESCRIPTION
### Summary:

Fixes part of #306 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

**This pr only include setup for GroupingService, will integrate GroupingService in a separate pr**

- Introduce Group interface that represents group used for categorization
- Refactor GithubUser as class and implement Group Interface
- Introduce GroupingStrategy interface to represent groupings logic based on different criteria (Follow Strategy design pattern)
- Implement Grouping Context Service that responsible for managing the grouping, includes retrieve grouped data and all applicable groups based on current GroupingStrategy.

### Proposed Commit Message:

```
Set up Grouping Strategy and Service

Implement GroupBy feature to allow users to group the issues/prs
based on different criteria such as milestone, status and etc.

Let's set up the Grouping Strategy and Service.
```
