### PR TITLE
Hide redundant column pagination

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -134,14 +134,14 @@ div.column-header .mat-card-header {
   font-size: 14px;
 }
 
-/deep/ .pagination-hide-arrow .mat-paginator-navigation-previous {
+:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous {
   display: none !important;
 }
 
-/deep/ .pagination-hide-arrow .mat-paginator-navigation-next {
+:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-next {
   display: none !important;
 }
 
-/deep/ .mat-paginator-range-actions {
+:host ::ng-deep .mat-paginator-range-actions {
   height: 47px;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -133,3 +133,15 @@ div.column-header .mat-card-header {
   display: inline-flex;
   font-size: 14px;
 }
+
+/deep/ .pagination-hide-arrow .mat-paginator-navigation-previous {
+  display: none !important;
+}
+
+/deep/ .pagination-hide-arrow .mat-paginator-navigation-next {
+  display: none !important;
+}
+
+/deep/ .mat-paginator-range-actions {
+  height: 47px;
+}

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -28,5 +28,10 @@
       </mat-card>
     </div>
   </div>
-  <mat-paginator [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>
+  <mat-paginator
+    [pageSize]="pageSize"
+    [pageSizeOptions]="[10, 20, 50]"
+    [class]="pageSize > issueLength ? 'pagination-hide-arrow' : ''"
+    (page)="updatePageSize($event.pageSize)"
+  ></mat-paginator>
 </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -31,7 +31,7 @@
   <mat-paginator
     [pageSize]="pageSize"
     [pageSizeOptions]="[10, 20, 50]"
-    [class]="pageSize > issueLength ? 'pagination-hide-arrow' : ''"
+    [class]="pageSize >= issueLength ? 'pagination-hide-arrow' : ''"
     (page)="updatePageSize($event.pageSize)"
   ></mat-paginator>
 </div>

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -30,7 +30,7 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   isLoading = true;
   issueLength = 0;
 
-  pageSize: number = 20;
+  pageSize = 20;
 
   @Output() issueLengthChange: EventEmitter<Number> = new EventEmitter<Number>();
 

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -30,6 +30,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   isLoading = true;
   issueLength = 0;
 
+  pageSize: number = 20;
+
   @Output() issueLengthChange: EventEmitter<Number> = new EventEmitter<Number>();
 
   constructor(public element: ElementRef, public issueService: IssueService) {}
@@ -44,8 +46,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
       this.issues$ = this.issues.connect();
 
       // Emit event when issues change
-      this.issues$.subscribe((issues) => {
-        this.issueLength = issues.length;
+      this.issues$.subscribe(() => {
+        this.issueLength = this.issues.count;
         this.issueLengthChange.emit(this.issueLength);
       });
 
@@ -64,5 +66,9 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
 
   retrieveFilterable(): FilterableSource {
     return this.issues;
+  }
+
+  updatePageSize(newPageSize: number) {
+    this.pageSize = newPageSize;
   }
 }


### PR DESCRIPTION
### Summary:

Fixes #298

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

* Compare issue count with pagination page size to decide on whether to assign class to hide pagination arrow
* Apply CSS styling to hide arrow
* Use mat-pagination event listener to update pagination page size.

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/9fafd711-2a7b-4eee-af06-3a9b4f0ff5af)

### Proposed Commit Message:

```
Hide redundant column pagination

Column pagination arrows cause unnecessary clogs
if they are disabled.

We hide arrows on columns that only has one page.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
