### PR TITLE
Status filter checkboxes

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -46,4 +46,26 @@ export class FiltersService {
     };
     this.filter$.next(nextDropdownFilter);
   }
+
+  sanitizeLabels(allLabels: SimpleLabel[]) {
+    const allLabelsSet = new Set(allLabels.map((label) => label.name));
+
+    const newHiddenLabels: Set<string> = new Set();
+    for (const hiddenLabel of this.filter$.value.hiddenLabels) {
+      if (allLabelsSet.has(hiddenLabel)) {
+        newHiddenLabels.add(hiddenLabel);
+      }
+    }
+
+    const newDeselectedLabels: Set<string> = new Set();
+    for (const deselectedLabel of this.filter$.value.deselectedLabels) {
+      if (allLabelsSet.has(deselectedLabel)) {
+        newDeselectedLabels.add(deselectedLabel);
+      }
+    }
+
+    const newLabels = this.filter$.value.labels.filter((label) => allLabelsSet.has(label));
+
+    this.updateFilters({ labels: newLabels, hiddenLabels: newHiddenLabels, deselectedLabels: newDeselectedLabels });
+  }
 }

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -12,22 +12,9 @@ export type Filter = {
   hiddenLabels?: Set<string>;
 };
 
-type StatusInfo = {
-  type: string;
-  status: string;
-};
-
-/**
- * Converts a status string into an info object
- */
-export const statusToType = (statusString: string): StatusInfo => {
-  const [status, type] = statusString.split(' ');
-  return { status, type };
-};
-
 export const DEFAULT_FILTER: Filter = {
   title: '',
-  status: ['open pullrequest', 'merged pullrequest', 'closed pullrequest', 'open issue', 'closed issue'],
+  status: ['open pullrequest', 'merged pullrequest', 'open issue', 'closed issue'],
   type: 'all',
   sort: { active: 'id', direction: 'asc' },
   labels: [],

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -49,7 +49,7 @@ export class FiltersService {
   }
 
   updateFilters(newFilters: Partial<Filter>): void {
-    let nextDropdownFilter: Filter = {
+    const nextDropdownFilter: Filter = {
       ...this.filter$.value,
       ...newFilters
     };

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, pipe } from 'rxjs';
 
 export type Filter = {
   title: string;
-  status: string;
+  status: string[];
   type: string;
   sort: Sort;
   labels: string[];
@@ -12,9 +12,22 @@ export type Filter = {
   hiddenLabels?: Set<string>;
 };
 
+type StatusInfo = {
+  type: string;
+  status: string;
+};
+
+/**
+ * Converts a status string into an info object
+ */
+export const statusToType = (statusString: string): StatusInfo => {
+  const [status, type] = statusString.split(' ');
+  return { status, type };
+};
+
 export const DEFAULT_FILTER: Filter = {
   title: '',
-  status: 'all',
+  status: ['open pullrequest', 'merged pullrequest', 'closed pullrequest', 'open issue', 'closed issue'],
   type: 'all',
   sort: { active: 'id', direction: 'asc' },
   labels: [],
@@ -31,8 +44,6 @@ export const DEFAULT_FILTER: Filter = {
 export class FiltersService {
   public filter$ = new BehaviorSubject<Filter>(DEFAULT_FILTER);
 
-  private _validateFilter = pipe(this.updateStatusPairing, this.updateTypePairing);
-
   clearFilters(): void {
     this.filter$.next(DEFAULT_FILTER);
   }
@@ -42,29 +53,6 @@ export class FiltersService {
       ...this.filter$.value,
       ...newFilters
     };
-
-    nextDropdownFilter = this._validateFilter(nextDropdownFilter);
-
     this.filter$.next(nextDropdownFilter);
-  }
-
-  /**
-   * Changes type to a valid, default value when an incompatible combination of type and status is encountered.
-   */
-  updateTypePairing(dropdownFilter: Filter): Filter {
-    if (dropdownFilter.status === 'merged') {
-      dropdownFilter.type = 'pullrequest';
-    }
-    return dropdownFilter;
-  }
-
-  /**
-   * Changes status to a valid, default value when an incompatible combination of type and status is encountered.
-   */
-  updateStatusPairing(dropdownFilter: Filter): Filter {
-    if (dropdownFilter.status === 'merged' && dropdownFilter.type === 'issue') {
-      dropdownFilter.status = 'all';
-    }
-    return dropdownFilter;
   }
 }

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -9,11 +9,12 @@
     <div class="dropdown-filters">
       <mat-form-field appearance="standard">
         <mat-label>Status</mat-label>
-        <mat-select [value]="this.filter.status" (selectionChange)="this.filtersService.updateFilters({ status: $event.value })">
-          <mat-option value="all">All</mat-option>
-          <mat-option value="open">Open</mat-option>
-          <mat-option value="closed">Closed</mat-option>
-          <mat-option value="merged" *ngIf="isNotFilterIssue()">Merged</mat-option>
+        <mat-select [value]="this.filter.status" (selectionChange)="this.filtersService.updateFilters({ status: $event.value })" multiple>
+          <mat-option *ngIf="isFilterPullRequest()" value="open pullrequest">Open Pull Requests</mat-option>
+          <mat-option *ngIf="isFilterPullRequest()" value="merged pullrequest">Merged Pull Requests</mat-option>
+          <mat-option *ngIf="isFilterPullRequest()" value="closed pullrequest">Closed Pull Request</mat-option>
+          <mat-option *ngIf="isFilterIssue()" value="open issue">Open Issues</mat-option>
+          <mat-option *ngIf="isFilterIssue()" value="closed issue">Closed Issues</mat-option>
         </mat-select>
       </mat-form-field>
       <mat-form-field appearance="standard">

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -67,8 +67,12 @@ export class FilterBarComponent implements OnInit, AfterViewInit, OnDestroy {
   /**
    * Checks if program is filtering by type issue.
    */
-  isNotFilterIssue() {
-    return this.filter.type !== 'issue';
+  isFilterIssue() {
+    return this.filter.type === 'issue' || this.filter.type === 'all';
+  }
+
+  isFilterPullRequest() {
+    return this.filter.type === 'pullrequest' || this.filter.type === 'all';
   }
 
   /**

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -34,7 +34,6 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       this.labels$ = this.labelService.connect();
       this.labels$.subscribe((labels) => {
         this.allLabels = labels;
-        this.filtersService.sanitizeLabels(this.allLabels);
         this.selectedLabelNames = this.filtersService.filter$.value.labels;
         this.hiddenLabelNames = this.filtersService.filter$.value.hiddenLabels;
       });

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -36,7 +36,9 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       this.labels$ = this.labelService.connect();
       this.labels$.subscribe((labels) => {
         this.allLabels = labels;
+        this.filtersService.sanitizeLabels(this.allLabels);
         this.selectedLabelNames = new Set<string>(this.filtersService.filter$.value.labels);
+        this.deselectedLabelNames = this.filtersService.filter$.value.deselectedLabels;
         this.hiddenLabelNames = this.filtersService.filter$.value.hiddenLabels;
       });
     });

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -9,7 +9,7 @@ type StatusInfo = {
 /**
  * Converts a status string into an info object
  */
-export const statusToType = (statusString: string): StatusInfo => {
+const infoFromStatus = (statusString: string): StatusInfo => {
   const [status, type] = statusString.split(' ');
   return { status, type };
 };
@@ -28,7 +28,7 @@ export function applyDropdownFilter(filter: Filter, data: Issue[]): Issue[] {
     ret =
       ret &&
       filter.status.some((item) => {
-        const statusInfo = statusToType(item);
+        const statusInfo = infoFromStatus(item);
         return statusInfo.status === issue.state.toLowerCase() && statusInfo.type === issue.issueOrPr.toLowerCase();
       });
 

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -1,5 +1,18 @@
 import { Issue } from '../../core/models/issue.model';
-import { Filter, statusToType } from '../../core/services/filters.service';
+import { Filter } from '../../core/services/filters.service';
+
+type StatusInfo = {
+  type: string;
+  status: string;
+};
+
+/**
+ * Converts a status string into an info object
+ */
+export const statusToType = (statusString: string): StatusInfo => {
+  const [status, type] = statusString.split(' ');
+  return { status, type };
+};
 
 /**
  * This module serves to improve separation of concerns in IssuesDataTable.ts and IssueList.ts module by containing the logic for

--- a/src/app/shared/issue-tables/dropdownfilter.ts
+++ b/src/app/shared/issue-tables/dropdownfilter.ts
@@ -1,5 +1,5 @@
 import { Issue } from '../../core/models/issue.model';
-import { Filter } from '../../core/services/filters.service';
+import { Filter, statusToType } from '../../core/services/filters.service';
 
 /**
  * This module serves to improve separation of concerns in IssuesDataTable.ts and IssueList.ts module by containing the logic for
@@ -11,14 +11,13 @@ export function applyDropdownFilter(filter: Filter, data: Issue[]): Issue[] {
   const filteredData: Issue[] = data.filter((issue) => {
     let ret = true;
 
-    if (filter.status === 'open') {
-      ret = ret && issue.state === 'OPEN';
-    } else if (filter.status === 'closed') {
-      // there is apparently also a status called 'all' based on github api
-      ret = ret && issue.state === 'CLOSED';
-    } else if (filter.status === 'merged') {
-      ret = ret && issue.state === 'MERGED';
-    }
+    // status can either be 'open', 'closed', or 'merged'
+    ret =
+      ret &&
+      filter.status.some((item) => {
+        const statusInfo = statusToType(item);
+        return statusInfo.status === issue.state.toLowerCase() && statusInfo.type === issue.issueOrPr.toLowerCase();
+      });
 
     if (filter.type === 'issue') {
       ret = ret && issue.issueOrPr === 'Issue';

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -49,7 +49,6 @@ describe('LabelFilterBarComponent', () => {
       labelsSubject = new BehaviorSubject<SimpleLabel[]>([]);
       labelServiceSpy.fetchLabels.and.returnValue(of([]));
       labelServiceSpy.connect.and.returnValue(labelsSubject.asObservable());
-      filtersServiceSpy.sanitizeLabels.and.callThrough();
     });
 
     // it('should update allLabels with latest emmitted value after ngAfterViewInit', fakeAsync(() => {

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -49,6 +49,7 @@ describe('LabelFilterBarComponent', () => {
       labelsSubject = new BehaviorSubject<SimpleLabel[]>([]);
       labelServiceSpy.fetchLabels.and.returnValue(of([]));
       labelServiceSpy.connect.and.returnValue(labelsSubject.asObservable());
+      filtersServiceSpy.sanitizeLabels.and.callThrough();
     });
 
     // it('should update allLabels with latest emmitted value after ngAfterViewInit', fakeAsync(() => {


### PR DESCRIPTION
### Summary:

Fixes #296

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

* Change `Filter::status` type from `string` to `string[]`
* Revise `dropdownfilter` to filter according to the new representation
* Remove filter validation, since there is no need with this new design
* Allow multiple selection in status filter dropdown
* Dropdown option only appears if the value for `Filter::type` is correct

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/41623a90-e250-40e8-8fd9-9742997a51f6)

### Proposed Commit Message:

```
Status filter checkboxes

We implement checkboxes for status, so that
multiple types of PRs/issues can be viewed concurrently.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
