### PR TITLE
Include groupby params in url

### DIFF
--- a/src/app/core/services/grouping/grouping-context.service.ts
+++ b/src/app/core/services/grouping/grouping-context.service.ts
@@ -47,19 +47,17 @@ export class GroupingContextService {
     const groupByParam = this.route.snapshot.queryParamMap.get(GroupingContextService.GROUP_BY_QUERY_PARAM_KEY);
 
     if (groupByParam && Object.values(GroupBy).includes(groupByParam as GroupBy)) {
-      this.setCurrentGroupingType(groupByParam as GroupBy, true);
+      this.setCurrentGroupingType(groupByParam as GroupBy);
     } else {
-      this.setCurrentGroupingType(DEFAULT_GROUPBY, true);
+      this.setCurrentGroupingType(DEFAULT_GROUPBY);
     }
   }
 
   /**
    * Sets the current grouping type and updates the corresponding query parameter in the URL.
    * @param groupBy The grouping type to set.
-   * @param replaceUrl Determines whether to replace the current URL in the browser's history.
-   *                   If true, it replaces the URL; if false, it adds a new entry to the history.
    */
-  setCurrentGroupingType(groupBy: GroupBy, replaceUrl: boolean): void {
+  setCurrentGroupingType(groupBy: GroupBy): void {
     this.currGroupBy = groupBy;
     this.currGroupBySubject.next(this.currGroupBy);
 
@@ -69,7 +67,7 @@ export class GroupingContextService {
         [GroupingContextService.GROUP_BY_QUERY_PARAM_KEY]: groupBy
       },
       queryParamsHandling: 'merge',
-      replaceUrl: replaceUrl
+      replaceUrl: true
     });
   }
 
@@ -107,6 +105,6 @@ export class GroupingContextService {
    * Resets the current grouping type to the default.
    */
   reset(): void {
-    this.setCurrentGroupingType(DEFAULT_GROUPBY, false);
+    this.setCurrentGroupingType(DEFAULT_GROUPBY);
   }
 }

--- a/src/app/core/services/grouping/grouping-context.service.ts
+++ b/src/app/core/services/grouping/grouping-context.service.ts
@@ -19,7 +19,7 @@ export const DEFAULT_GROUPBY = GroupBy.Assignee;
   providedIn: 'root'
 })
 export class GroupingContextService {
-  public static readonly GROUP_BY_QUERY_PARAM_KEY = "groupby";
+  public static readonly GROUP_BY_QUERY_PARAM_KEY = 'groupby';
   private currGroupBySubject: BehaviorSubject<GroupBy>;
   currGroupBy: GroupBy;
   currGroupBy$: Observable<GroupBy>;
@@ -38,8 +38,19 @@ export class GroupingContextService {
   }
 
   /**
-   * Sets the current grouping type.
-   * @param groupBy - The grouping type to set.
+   * Initializes the service from URL parameters.
+   */
+  initializeFromUrlParams() {
+    const groupByParam = this.route.snapshot.queryParamMap.get(GroupingContextService.GROUP_BY_QUERY_PARAM_KEY);
+
+    if (groupByParam && Object.values(GroupBy).includes(groupByParam as GroupBy)) {
+      this.setCurrentGroupingType(groupByParam as GroupBy, true);
+    } else {
+      this.setCurrentGroupingType(DEFAULT_GROUPBY, true);
+    }
+  }
+
+  /**
    * Sets the current grouping type and updates the corresponding query parameter in the URL.
    * @param groupBy The grouping type to set.
    * @param replaceUrl Determines whether to replace the current URL in the browser's history.
@@ -93,6 +104,6 @@ export class GroupingContextService {
    * Resets the current grouping type to the default.
    */
   reset(): void {
-    this.setCurrentGroupingType(DEFAULT_GROUPBY, true);
+    this.setCurrentGroupingType(DEFAULT_GROUPBY, false);
   }
 }

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -88,7 +88,8 @@ export class ViewService {
     this.router.navigate(['issuesViewer'], {
       queryParams: {
         [ViewService.REPO_QUERY_PARAM_KEY]: repo.toString()
-      }
+      },
+      queryParamsHandling: 'merge'
     });
   }
 

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -32,6 +32,8 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   popStateEventSubscription: Subscription;
 
+  availableGroupsSubscription: Subscription;
+
   popStateNavigationId: number;
 
   /** Users to show as columns */
@@ -95,6 +97,10 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
    * Fetch and initialize all information from repository to populate Issue Dashboard.
    */
   private initialize() {
+    if (this.availableGroupsSubscription) {
+      this.availableGroupsSubscription.unsubscribe();
+    }
+
     this.checkIfValidRepository().subscribe((isValidRepository) => {
       if (!isValidRepository) {
         throw new Error(ErrorMessageService.repositoryNotPresentMessage());
@@ -105,7 +111,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.groups = [];
     this.hiddenGroups = [];
 
-    this.groupingContextService.getGroups().subscribe((x) => (this.groups = x));
+    this.availableGroupsSubscription = this.groupingContextService.getGroups().subscribe((x) => (this.groups = x));
 
     // Fetch issues
     this.issueService.reloadAllIssues();

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -1,5 +1,7 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { BehaviorSubject, of, Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { Group } from '../core/models/github/group.interface';
 import { Repo } from '../core/models/repo.model';
 import { ErrorMessageService } from '../core/services/error-message.service';
@@ -28,6 +30,10 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Observes for any change in the cardviews */
   viewChange: Subscription;
 
+  popStateEventSubscription: Subscription;
+
+  popStateNavigationId: number;
+
   /** Users to show as columns */
   groups: Group[] = [];
 
@@ -44,7 +50,8 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     public issueService: IssueService,
     public labelService: LabelService,
     public milestoneService: MilestoneService,
-    public groupingContextService: GroupingContextService
+    public groupingContextService: GroupingContextService,
+    private router: Router
   ) {
     this.repoChangeSubscription = this.viewService.repoChanged$.subscribe((newRepo) => {
       this.issueService.reset(false);
@@ -55,10 +62,23 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.groupByChangeSubscription = this.groupingContextService.currGroupBy$.subscribe((newGroupBy) => {
       this.initialize();
     });
+
+    this.popStateEventSubscription = this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd || event instanceof NavigationStart))
+      .subscribe((event) => {
+        if (event instanceof NavigationStart && event.navigationTrigger === 'popstate') {
+          this.popStateNavigationId = event.id;
+        }
+
+        if (event instanceof NavigationEnd && event.id === this.popStateNavigationId) {
+          this.groupingContextService.initializeFromUrlParams();
+        }
+      });
   }
 
   ngOnInit() {
     this.initialize();
+    this.groupingContextService.initializeFromUrlParams();
   }
 
   ngAfterViewInit(): void {
@@ -68,6 +88,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     this.repoChangeSubscription.unsubscribe();
     this.viewChange.unsubscribe();
+    this.popStateEventSubscription.unsubscribe();
   }
 
   /**

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -16,7 +16,7 @@
         <mat-label>Group by</mat-label>
         <mat-select
           [value]="this.groupingContextService.currGroupBy$ | async"
-          (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value, false)"
+          (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value)"
         >
           <mat-option *ngFor="let option of this.groupByEnum | keyvalue" [value]="option.value">{{ option.key }}</mat-option>
         </mat-select>

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -16,7 +16,7 @@
         <mat-label>Group by</mat-label>
         <mat-select
           [value]="this.groupingContextService.currGroupBy$ | async"
-          (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value)"
+          (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value, false)"
         >
           <mat-option *ngFor="let option of this.groupByEnum | keyvalue" [value]="option.value">{{ option.key }}</mat-option>
         </mat-select>

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -39,7 +39,9 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   disconnect() {
     this.filterChange.complete();
     this.issuesSubject.complete();
-    this.issueSubscription.unsubscribe();
+    if (this.issueSubscription) {
+      this.issueSubscription.unsubscribe();
+    }
     this.issueService.stopPollIssues();
   }
 

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -14,6 +14,7 @@ import { ErrorHandlingService } from '../../core/services/error-handling.service
 import { FiltersService } from '../../core/services/filters.service';
 import { GithubService } from '../../core/services/github.service';
 import { GithubEventService } from '../../core/services/githubevent.service';
+import { GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 import { IssueService } from '../../core/services/issue.service';
 import { LabelService } from '../../core/services/label.service';
 import { LoggingService } from '../../core/services/logging.service';
@@ -61,7 +62,8 @@ export class HeaderComponent implements OnInit {
     private githubService: GithubService,
     private dialogService: DialogService,
     private repoSessionStorageService: RepoSessionStorageService,
-    private filtersService: FiltersService
+    private filtersService: FiltersService,
+    private groupingContextService: GroupingContextService
   ) {
     router.events
       .pipe(
@@ -237,6 +239,7 @@ export class HeaderComponent implements OnInit {
 
     if (!keepFilters) {
       this.filtersService.clearFilters();
+      this.groupingContextService.reset();
     }
 
     this.viewService

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -239,7 +239,6 @@ export class HeaderComponent implements OnInit {
 
     if (!keepFilters) {
       this.filtersService.clearFilters();
-      this.groupingContextService.reset();
     }
 
     this.viewService
@@ -247,6 +246,7 @@ export class HeaderComponent implements OnInit {
       .then(() => {
         this.auth.setTitleWithViewDetail();
         this.currentRepo = newRepoString;
+        this.groupingContextService.reset();
       })
       .catch((error) => {
         this.openChangeRepoDialog();

--- a/tests/services/view.service.spec.ts
+++ b/tests/services/view.service.spec.ts
@@ -51,7 +51,8 @@ describe('ViewService', () => {
       viewService.setRepository(WATCHER_REPO);
 
       expect(routerSpy.navigate).toHaveBeenCalledWith(['issuesViewer'], {
-        queryParams: { repo: WATCHER_REPO.toString() }
+        queryParams: { repo: WATCHER_REPO.toString() },
+        queryParamsHandling: 'merge'
       });
     });
   });
@@ -88,7 +89,8 @@ describe('ViewService', () => {
       expect(loggingServiceSpy.info).toHaveBeenCalledWith(`ViewService: Changing current repository to '${WATCHER_REPO}'`);
       expect(viewService.currentRepo).toEqual(WATCHER_REPO);
       expect(routerSpy.navigate).toHaveBeenCalledWith(['issuesViewer'], {
-        queryParams: { repo: WATCHER_REPO.toString() }
+        queryParams: { repo: WATCHER_REPO.toString() },
+        queryParamsHandling: 'merge'
       });
       expect(repoUrlCacheServiceSpy.cache).toHaveBeenCalledWith(WATCHER_REPO.toString());
       expect(repoChanged$Spy).toHaveBeenCalledWith(WATCHER_REPO);
@@ -115,7 +117,8 @@ describe('ViewService', () => {
       expect(loggingServiceSpy.info).toHaveBeenCalledWith(`ViewService: Repo is ${WATCHER_REPO}`);
       expect(viewService.currentRepo).toEqual(WATCHER_REPO);
       expect(routerSpy.navigate).toHaveBeenCalledWith(['issuesViewer'], {
-        queryParams: { repo: WATCHER_REPO.toString() }
+        queryParams: { repo: WATCHER_REPO.toString() },
+        queryParamsHandling: 'merge'
       });
       expect(repoSetSourceNext).toHaveBeenCalledWith(true);
     });


### PR DESCRIPTION
### Summary:

Fixes #317

#### Type of change:

(Delete where appropriate)

- ✨ New Feature/ Enhancement

### Changes Made:

- Update `setCurrentGroupingType` method: Allow setting the `replaceUrl` field
  - True: Replace the current url state in history
  - False: Push a new url state to history
- Implement initialization with url for `GroupingContextService`
   - Initialize when init `IssueViewer` page
   - Initialize when clicking back button or forward button ("popstate")
- Reset `GroupingContextService` if not keeping filter when switching repo
- Preserve previous url param when changing repo (`ViewService`)
  - Include the field `queryParamHandling: 'merge'`

### Proposed Commit Message:

```
Include groupby parameters in URL

With groupby parameters in the URL, users can easily share 
the current grouping by using the URL.

Let's implement initialization with URL parameters and 
the ability to set groupby parameters.
```
