### PR TITLE
Add preset views

### DIFF
--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -5,10 +5,12 @@ export class Milestone {
   static DefaultMilestone: Milestone = new Milestone({ title: 'Without a milestone', state: null });
   title: string;
   state: string;
+  deadline?: Date;
 
-  constructor(milestone: { title: string; state: string }) {
+  constructor(milestone: { title: string; state: string; due_on?: string }) {
     this.title = milestone.title;
     this.state = milestone.state;
+    this.deadline = milestone.due_on ? new Date(milestone.due_on) : undefined;
   }
 
   public equals(milestone: Milestone) {

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -51,7 +51,7 @@ export class FiltersService {
   };
 
   // List of keys in the new filter change that causes current filter to not qualify to be a preset view.
-  readonly presetChangingKeys = new Set<string>(['status', 'type', 'milestones', 'labels', 'hiddenLabels', 'deselectedLabels']);
+  readonly presetChangingKeys = new Set<string>(['status', 'type', 'milestones', 'labels', 'deselectedLabels']);
 
   readonly defaultFilter = this.presetViews.currentlyActive;
   public filter$ = new BehaviorSubject<Filter>(this.defaultFilter());

--- a/src/app/core/services/milestone.service.ts
+++ b/src/app/core/services/milestone.service.ts
@@ -13,7 +13,7 @@ import { GithubService } from './github.service';
  * from the GitHub repository for the WATcher application.
  */
 export class MilestoneService {
-  milestones: Milestone[];
+  milestones: Milestone[] = [];
   hasNoMilestones: boolean;
 
   constructor(private githubService: GithubService) {}

--- a/src/app/core/services/milestone.service.ts
+++ b/src/app/core/services/milestone.service.ts
@@ -47,4 +47,42 @@ export class MilestoneService {
     milestoneData.push(Milestone.DefaultMilestone);
     return milestoneData;
   }
+
+  /**
+   * Gets the open milestone with the earliest deadline.
+   * Returns null if there is no open milestone with deadline.
+   */
+  getEarliestOpenMilestone(): Milestone {
+    let earliestOpenMilestone: Milestone = null;
+    for (const milestone of this.milestones) {
+      if (!milestone.deadline || milestone.state !== 'open') {
+        continue;
+      }
+      if (earliestOpenMilestone === null) {
+        earliestOpenMilestone = milestone;
+      } else if (milestone.deadline < earliestOpenMilestone.deadline) {
+        earliestOpenMilestone = milestone;
+      }
+    }
+    return earliestOpenMilestone;
+  }
+
+  /**
+   * Gets the closed milestone with the latest deadline.
+   * Returns null if there is no closed milestone with deadline.
+   */
+  getLatestClosedMilestone(): Milestone {
+    let latestClosedMilestone: Milestone = null;
+    for (const milestone of this.milestones) {
+      if (!milestone.deadline || milestone.state !== 'closed') {
+        continue;
+      }
+      if (latestClosedMilestone === null) {
+        latestClosedMilestone = milestone;
+      } else if (milestone.deadline > latestClosedMilestone.deadline) {
+        latestClosedMilestone = milestone;
+      }
+    }
+    return latestClosedMilestone;
+  }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -14,6 +14,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { Observable } from 'rxjs';
 import { Group } from '../../core/models/github/group.interface';
 import { Issue } from '../../core/models/issue.model';
+import { FiltersService } from '../../core/services/filters.service';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 import { IssueService } from '../../core/services/issue.service';
 import { FilterableComponent, FilterableSource } from '../../shared/issue-tables/filterableTypes';
@@ -47,12 +48,18 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
 
   @Output() issueLengthChange: EventEmitter<Number> = new EventEmitter<Number>();
 
-  constructor(public element: ElementRef, public issueService: IssueService, public groupingContextService: GroupingContextService) {}
+  constructor(
+    public element: ElementRef,
+    public issueService: IssueService,
+    public groupingContextService: GroupingContextService,
+    private filtersService: FiltersService
+  ) {}
 
   ngOnInit() {
     this.issues = new IssuesDataTable(
       this.issueService,
       this.groupingContextService,
+      this.filtersService,
       this.paginator,
       this.headers,
       this.group,

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, OnDestroy, OnInit, QueryList, ViewChild } from '@angular/core';
 import { MatSelect } from '@angular/material/select';
 import { BehaviorSubject, Subscription } from 'rxjs';
-import { DEFAULT_FILTER, Filter, FiltersService } from '../../core/services/filters.service';
+import { Filter, FiltersService } from '../../core/services/filters.service';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { MilestoneService } from '../../core/services/milestone.service';
@@ -24,7 +24,7 @@ export class FilterBarComponent implements OnInit, OnDestroy {
   repoChangeSubscription: Subscription;
 
   /** Selected dropdown filter value */
-  filter: Filter = DEFAULT_FILTER;
+  filter: Filter = this.filtersService.defaultFilter();
 
   groupByEnum: typeof GroupBy = GroupBy;
 

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, merge, Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Group } from '../../core/models/github/group.interface';
 import { Issue } from '../../core/models/issue.model';
-import { DEFAULT_FILTER, Filter } from '../../core/services/filters.service';
+import { Filter, FiltersService } from '../../core/services/filters.service';
 import { GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 import { IssueService } from '../../core/services/issue.service';
 import { applyDropdownFilter } from './dropdownfilter';
@@ -15,7 +15,7 @@ import { applySearchFilter } from './search-filter';
 
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;
-  private filterChange = new BehaviorSubject(DEFAULT_FILTER);
+  private filterChange = new BehaviorSubject(this.filtersService.defaultFilter());
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
 
@@ -24,6 +24,7 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   constructor(
     private issueService: IssueService,
     private groupingContextService: GroupingContextService,
+    private filtersService: FiltersService,
     private paginator: MatPaginator,
     private displayedColumn: string[],
     private group?: Group,

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -15,6 +15,7 @@
     ({{ this.presetViews[this.filtersService.presetView$.value] }})
   </span>
 
+  <!-- Gateway to activity dashboard, do not delete -->
   <!--div *ngIf="auth.isAuthenticated() && this.viewService.sessionData.sessionRepo.length > 1">
     <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white">expand_more</mat-icon></button>
     <mat-menu #menu="matMenu">

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -12,10 +12,10 @@
     >WATcher v{{ this.getVersion() }}</a
   >
   <span id="view-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
-    ({{ this.getViewDescription(viewService.currentView) }})
+    ({{ this.presetViews[this.filtersService.presetView$.value] }})
   </span>
 
-  <div *ngIf="auth.isAuthenticated() && this.viewService.sessionData.sessionRepo.length > 1">
+  <!--div *ngIf="auth.isAuthenticated() && this.viewService.sessionData.sessionRepo.length > 1">
     <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white">expand_more</mat-icon></button>
     <mat-menu #menu="matMenu">
       <button
@@ -28,6 +28,25 @@
             >done</mat-icon
           >
           {{ this.getViewDescription(sessionRepo.view) }}
+        </span>
+      </button>
+    </mat-menu>
+  </div-->
+
+  <div *ngIf="auth.isAuthenticated()">
+    <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white">expand_more</mat-icon></button>
+    <mat-menu #menu="matMenu">
+      <button
+        mat-menu-item
+        *ngFor="let presetView of this.presetViews | keyvalue"
+        (click)="this.filtersService.updatePresetView(presetView.key)"
+      >
+        <span>
+          <mat-icon
+            [ngStyle]="{ color: 'green', visibility: this.filtersService.presetView$.value === presetView.key ? 'visible' : 'hidden' }"
+            >done</mat-icon
+          >
+          {{ presetView.value }}
         </span>
       </button>
     </mat-menu>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -43,6 +43,14 @@ export class HeaderComponent implements OnInit {
   private readonly yesButtonDialogMessage = 'Yes, I wish to log out';
   private readonly noButtonDialogMessage = "No, I don't wish to log out";
 
+  readonly presetViews: {
+    [key: string]: string;
+  } = {
+    currentlyActive: 'Currently active',
+    contributions: 'Contributions',
+    custom: 'Custom'
+  };
+
   /** Model for the displayed repository name */
   currentRepo = '';
 


### PR DESCRIPTION
### Summary:

Fixes #300

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Add deadline field to milestone.
- Add preset views.
- Apply preset views on filters.
- Change header to contain a button to select preset view.

"Currently active" preset view depends on sorting by status, so changes in this PR will fully work when #318 is merged.

Any changes made to type, status and milestones filters will set the preset view value to "custom".

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/87511888/2b00828c-2cbb-4a35-a3ae-055a84e5e736)

### Proposed Commit Message:

```
Add preset views

Currently, there are a lot of options of filters,
but there are no suggested useful preset views.

We add preset views for users to choose from,
and via a button on the header.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
