### PR TITLE
Update repo on back and forward navigation

### DIFF
--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { STORAGE_KEYS } from '../constants/storage-keys.constants';
@@ -69,6 +69,7 @@ export class ViewService {
     private githubService: GithubService,
     private repoUrlCacheService: RepoUrlCacheService,
     public logger: LoggingService,
+    private route: ActivatedRoute,
     private router: Router
   ) {}
 
@@ -181,6 +182,17 @@ export class ViewService {
         }
       })
     );
+  }
+
+  /**
+   * Initializes a repo based on the URL parameters and changes the repo if valid.
+   */
+  initializeRepoFromUrlParams(): void {
+    const repoParams = this.route.snapshot.queryParamMap.get(ViewService.REPO_QUERY_PARAM_KEY);
+
+    const newRepo = Repo.of(repoParams);
+
+    this.changeRepositoryIfValid(newRepo);
   }
 
   getViewAndRepoFromUrl(url: string): [string, string] {

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -73,6 +73,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
         }
 
         if (event instanceof NavigationEnd && event.id === this.popStateNavigationId) {
+          this.viewService.initializeRepoFromUrlParams();
           this.groupingContextService.initializeFromUrlParams();
         }
       });

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -98,6 +98,10 @@ export class HeaderComponent implements OnInit {
       }
     });
 
+    this.viewService.repoChanged$.subscribe((repo) => {
+      this.initializeRepoNameInTitle();
+    });
+
     this.isLoading$ = this.issueService.isLoading.asObservable();
   }
 


### PR DESCRIPTION
### Summary:

Fixes #321 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Implement method to initialize repo from url params
- Call it when encounter `popstate` event (when back or forward button clicked)


### Proposed Commit Message:

```
Update repository on back and forward navigation.

IssueViewer's repository is not updated when navigating back or forward
in the URL history. This will lead to inconsistency between the URL
parameters and the application state.

Let's ensure that IssueViewer's repository is updated on back and forward
navigation.
```
