### PR TITLE
Reset GroupingContextService only if "keep filter" is selected.

### DIFF
--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -254,7 +254,9 @@ export class HeaderComponent implements OnInit {
       .then(() => {
         this.auth.setTitleWithViewDetail();
         this.currentRepo = newRepoString;
-        this.groupingContextService.reset();
+        if (!keepFilters) {
+          this.groupingContextService.reset();
+        }
       })
       .catch((error) => {
         this.openChangeRepoDialog();


### PR DESCRIPTION
### Summary:

Fix the bug where `GroupingContextService` is reset when the keep filter option is selected.

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Add if block to check if keep filter option is selected before resetting

### Proposed Commit Message:

```
Reset GroupingContextService only if "keep filter" is selected.

GroupingContextService is being reset when the "keep filter" 
option is selected.

Let's check if the "keep filter" option is selected before
resetting the service.
```
