### PR TITLE
Fix default preset view

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -107,6 +107,12 @@ export class FiltersService {
         return;
       }
 
+      // No preset view and no other filters in params, use default view
+      if (!presetView && Object.keys(nextFilter).every((filterName) => queryParams.get(filterName) === null)) {
+        this.updatePresetView('currentlyActive');
+        return;
+      }
+
       for (const filterName of Object.keys(nextFilter)) {
         const stringifiedFilterData = queryParams.get(filterName);
         if (!stringifiedFilterData) {


### PR DESCRIPTION
### Summary:

Fixes #333 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Handle case of no url params when coming into WATcher
- Set the default to the currentlyActive preset view instead of overwriting the filters with itself, through which changing the preset view to custom

### Screenshots:
Initial view before change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/01bf8d75-38d7-4b91-be0a-1602f6403b16)
Initial view after change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/7d77b6a3-b6e2-4893-8a10-c4920e57ce34)

### Proposed Commit Message:

```
The default view is custom instead of currently active.

The default view should show the most relevant information
to users. This should be the currently active preset view.

Let's change the default view to be currently active.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
