### PR TITLE
Show prs without milestone

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -233,14 +233,14 @@ export class FiltersService {
   getMilestonesForCurrentlyActive(): Milestone[] {
     const earliestOpenMilestone = this.milestoneService.getEarliestOpenMilestone();
     if (earliestOpenMilestone) {
-      return [earliestOpenMilestone];
+      return [earliestOpenMilestone, Milestone.PRWithoutMilestone];
     }
 
     const latestClosedMilestone = this.milestoneService.getLatestClosedMilestone();
     if (latestClosedMilestone) {
-      return [latestClosedMilestone];
+      return [latestClosedMilestone, Milestone.PRWithoutMilestone];
     }
 
-    return this.milestoneService.milestones;
+    return [...this.milestoneService.milestones, Milestone.PRWithoutMilestone];
   }
 }


### PR DESCRIPTION
### Summary:

Fixes #332 

#### Type of change:

- ✨ Enhancement

### Changes Made:

- Include "prs without milestone" filter for "Currently Active" preset view

### Proposed Commit Message:

```
Show PRs without milestone in "Currently Active"

PRs without milestone required urgent action from the user.

Let's show it in the "Currently Active" preset view.
```
