### PR TITLE
Show preset view only when repo is set

### DIFF
--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -11,7 +11,7 @@
   <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="viewService.isRepoSet() ? viewService.currentView : null"
     >WATcher v{{ this.getVersion() }}</a
   >
-  <span id="view-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 70px">
+  <span id="view-descriptor" *ngIf="viewService.isRepoSet()" style="margin-left: 70px">
     {{ this.presetViews[this.filtersService.presetView$.value] }}
   </span>
 
@@ -34,7 +34,7 @@
     </mat-menu>
   </div-->
 
-  <div *ngIf="auth.isAuthenticated()">
+  <div *ngIf="viewService.isRepoSet()">
     <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white">expand_more</mat-icon></button>
     <mat-menu #menu="matMenu">
       <div *ngFor="let presetView of this.presetViews | keyvalue">


### PR DESCRIPTION
### Summary:

Fixes #352 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change ngIf behaviour to show preset view and preset view selector only when repo is set

### Screenshots:
Before the change when no repo is selected
![image](https://github.com/CATcher-org/WATcher/assets/88131400/0d3fcbb2-e86e-4a97-a6ab-77f5f881569d)
After the change when no repo is selected
![image](https://github.com/CATcher-org/WATcher/assets/88131400/a4eba85a-8e2d-4ef9-a310-61c95b1e6c04)

### Proposed Commit Message:

```
Preset view is shown before a repo is selected.

There is no reason to show the current preset
view and might confuse users as to its purpose
when no repo is selected.

Let's hide the preset view until a repo is selected.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
