### PR TITLE
Fix top shadow hiding of columns

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -87,12 +87,12 @@ div.column-header .mat-card-header {
   display: none;
 }
 
-.scrollable-container-wrapper::before {
+.column-header::after {
   pointer-events: none;
   content: '';
   position: absolute;
   z-index: 1;
-  top: 0;
+  bottom: -6px;
   left: 0;
   right: 0;
   height: 5px;


### PR DESCRIPTION
### Summary:

Fixes #353 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change CSS style to be applied on column header instead of scrollable container wrapper

### Screenshots:
Before the change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/0fa11a84-e0c9-4798-a561-18d6fcc957b8)

After the change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/ecabb8ee-ba28-473b-a58f-a263329848b7)

### Proposed Commit Message:

```
A bug exists where the top shadow for columns is
hidden when they are scrolled

Let's ensure the column header shadows are not
hidden when scrolled.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
