### PR TITLE
Fix top and bottom shadow of columns

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -99,12 +99,16 @@ div.column-header .mat-card-header {
   background-image: radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.5), transparent);
 }
 
-.scrollable-container-wrapper::after {
+.mat-paginator {
+  position: relative;
+}
+
+.column-footer::before {
   pointer-events: none;
   content: '';
   position: absolute;
   z-index: 1;
-  bottom: 0;
+  top: -5px;
   left: 0;
   right: 0;
   height: 5px;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -106,10 +106,6 @@ div.column-header .mat-card-header {
   display: none;
 }
 
-.mat-paginator {
-  position: relative;
-}
-
 .loading-spinner {
   display: flex;
   justify-content: center;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -52,7 +52,26 @@ div.column-header .mat-card-header {
   position: relative;
 }
 
-/* Ref: https://css-scroll-shadows.vercel.app */
+/* Ref: https://lea.verou.me/blog/2012/04/background-attachment-local/ */
+.scroll-shadow {
+  background:
+    /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+    /* Shadows */ radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
+    radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+  background:
+    /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+    /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+  background-repeat: no-repeat;
+  background-color: white;
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
+}
+
 .scrollable-container::before {
   pointer-events: none;
   content: '';
@@ -87,32 +106,8 @@ div.column-header .mat-card-header {
   display: none;
 }
 
-.scrollable-container-wrapper::before {
-  pointer-events: none;
-  content: '';
-  position: absolute;
-  z-index: 1;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 5px;
-  background-image: radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.5), transparent);
-}
-
 .mat-paginator {
   position: relative;
-}
-
-.column-footer::before {
-  pointer-events: none;
-  content: '';
-  position: absolute;
-  z-index: 1;
-  top: -5px;
-  left: 0;
-  right: 0;
-  height: 5px;
-  background-image: radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.5), transparent);
 }
 
 .loading-spinner {

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -62,8 +62,8 @@ div.column-header .mat-card-header {
   background:
     /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)),
     linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
-    /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
-    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)) 0 100%;
   background-repeat: no-repeat;
   background-color: white;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -14,9 +14,10 @@
     </div>
   </div>
   <mat-paginator
+    class="column-footer"
     [pageSize]="pageSize"
     [pageSizeOptions]="[10, 20, 50]"
-    [class]="pageSize >= issueLength ? 'pagination-hide-arrow' : ''"
+    [class.pagination-hide-arrow]="pageSize >= issueLength"
     (page)="updatePageSize($event.pageSize)"
   ></mat-paginator>
 </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -16,7 +16,7 @@
   <mat-paginator
     [pageSize]="pageSize"
     [pageSizeOptions]="[10, 20, 50]"
-    [class.pagination-hide-arrow]="pageSize >= issueLength"
+    [class]="pageSize >= issueLength ? 'pagination-hide-arrow' : ''"
     (page)="updatePageSize($event.pageSize)"
   ></mat-paginator>
 </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -3,7 +3,7 @@
     [ngTemplateOutlet]="getHeaderTemplate() || defaultHeader"
     [ngTemplateOutletContext]="{ $implicit: this.group }"
   ></ng-container>
-  <div class="scrollable-container-wrapper">
+  <div class="scrollable-container-wrapper scroll-shadow">
     <div class="scrollable-container">
       <div class="issue-pr-cards" *ngFor="let issue of this.issues$ | async; index as i">
         <app-issue-pr-card [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService"></app-issue-pr-card>
@@ -14,7 +14,6 @@
     </div>
   </div>
   <mat-paginator
-    class="column-footer"
     [pageSize]="pageSize"
     [pageSizeOptions]="[10, 20, 50]"
     [class.pagination-hide-arrow]="pageSize >= issueLength"

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.css
@@ -1,5 +1,6 @@
 .card {
   margin: 8px 0px 8px 0px;
+  background-color: transparent;
 }
 
 .mat-card {


### PR DESCRIPTION
### Summary:

Fixes #354 
Fixes #353 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change CSS style for bottom shadow to use background image of scroll container
- Refactor shadow style into its own class
- Change background of child elements of scroll to transparent to be able to see background shadow
- Reflect new reference for css shadows

### Screenshots:
Before the change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/6fb70110-3a50-44dd-a7c7-65afdfdeaa43)
![image](https://github.com/CATcher-org/WATcher/assets/88131400/5124c933-002a-4386-9c76-b7859c3acde4)
After the change
![image](https://github.com/CATcher-org/WATcher/assets/88131400/12157f9e-3dd1-4f0a-af8b-71411c59861e)
![image](https://github.com/CATcher-org/WATcher/assets/88131400/4b9f60c6-543f-4980-940e-54fb97eac550)



### Proposed Commit Message:

```
A few bugs exist related to column shadows. 
Top shadow is shown when there are no elements
behind header and hidden when there are.
Bottom shadow sticks to the column as a user scrolls.

These are not the intended behaviour of the shadows
to indicate presence of elements behind above or
below columns respectively.

Let's update the CSS to correspond to
appropriate shadow behaviours.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
