### PR TITLE
Fix reset of filters on label fetch

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -189,6 +189,8 @@ export class FiltersService {
       const presetView = queryParams.get(FiltersService.PRESET_VIEW_QUERY_PARAM_KEY);
       if (presetView && this.presetViews.hasOwnProperty(presetView)) {
         this.updatePresetView(presetView);
+      } else {
+        this.updatePresetView('currentlyActive');
       }
     } catch (err) {
       this.logger.info(`FiltersService: Update filters from URL failed with an error: ${err}`);

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -59,7 +59,7 @@ export class FiltersService {
       milestones: this.milestoneService.milestones.map((milestone) => milestone.title),
       deselectedLabels: new Set<string>()
     }),
-    custom: () => this.filter$.value
+    custom: () => ({})
   };
 
   // List of keys in the new filter change that causes current filter to not qualify to be a preset view.
@@ -208,7 +208,7 @@ export class FiltersService {
   /**
    * Updates the filters without updating the preset view.
    * This should only be called when there are new labels/milestones.
-   * The preset view will be reapplied.
+   * The preset view will be reapplied in order to account for changes in milestone categories on upstream
    * @param newFilters The filters with new values
    */
   private updateFiltersWithoutUpdatingPresetView(newFilters: Partial<Filter>): void {

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -24,7 +24,7 @@ export class FilterBarComponent implements OnInit, OnDestroy {
   repoChangeSubscription: Subscription;
 
   /** Selected dropdown filter value */
-  filter: Filter = this.filtersService.defaultFilter();
+  filter: Filter = this.filtersService.defaultFilter;
 
   groupByEnum: typeof GroupBy = GroupBy;
 

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -16,7 +16,7 @@ import { applySearchFilter } from './search-filter';
 
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;
-  private filterChange = new BehaviorSubject(this.filtersService.defaultFilter());
+  private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
 


### PR DESCRIPTION
### Summary:

Fixes #372 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change type of preset views to partial filters
- Exclude properties that do not change preset views from preset view returned partial filter
- Add default filter separate from preset views
- Configure load from url to align with new behaviour

### Proposed Commit Message:

```
There is a bug where filters are reset when 
labels are fetched.

This bug can cause sudden, unprompted
changes to filters.

Let's change the filter's service behaviour
when fetching labels to stop resetting filters.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
