### PR TITLE
Enhance error message on incorrect organisation/repo name

### DIFF
--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -8,12 +8,12 @@ import { Injectable } from '@angular/core';
  * Contains all error message prompts to user.
  */
 export class ErrorMessageService {
-  public static organisationNotPresentMessage() {
-    return 'Invalid organisation name. Please provide a repository URL or repo name (Org/Repo Name) with a valid organisation name.';
+  public static repoPrefixNotPresentMessage() {
+    return 'Invalid repo prefix. Please provide a repository URL or repo name with a valid prefix (org/user name), using the format <ORG/USER_NAME>/<REPO_NAME>';
   }
 
   public static repositoryNotPresentMessage() {
-    return 'Invalid repository name. Please provide Github repository URL or the repository name in the format Org/Repository Name.';
+    return 'Invalid repository name. Please provide Github repository URL or the repository name in the format <ORG/USER_NAME>/<REPO_NAME>.';
   }
 
   public static invalidUrlMessage() {

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -8,8 +8,8 @@ import { Injectable } from '@angular/core';
  * Contains all error message prompts to user.
  */
 export class ErrorMessageService {
-  public static repoPrefixNotPresentMessage() {
-    return 'Invalid repo prefix. Provide a repository URL or repo name with a valid prefix. (e.g. <ORG/USER>/<REPO>)';
+  public static repoOwnerNotPresentMessage() {
+    return 'Invalid repo owner. Provide a repository URL or repo name (<ORG/USER>/<REPO>) with a valid organisation/user name';
   }
 
   public static repositoryNotPresentMessage() {

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -8,6 +8,10 @@ import { Injectable } from '@angular/core';
  * Contains all error message prompts to user.
  */
 export class ErrorMessageService {
+  public static organisationNotPresentMessage() {
+    return 'Invalid organisation name. Please provide a repository URL or repo name (Org/Repo Name) with a valid organisation name.';
+  }
+
   public static repositoryNotPresentMessage() {
     return 'Invalid repository name. Please provide Github repository URL or the repository name in the format Org/Repository Name.';
   }

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -9,11 +9,11 @@ import { Injectable } from '@angular/core';
  */
 export class ErrorMessageService {
   public static repoPrefixNotPresentMessage() {
-    return 'Invalid repo prefix. Please provide a repository URL or repo name with a valid prefix (org/user name), using the format <ORG/USER_NAME>/<REPO_NAME>';
+    return 'Invalid repo prefix. Provide a repository URL or repo name with a valid prefix. (e.g. <ORG/USER>/<REPO>)';
   }
 
   public static repositoryNotPresentMessage() {
-    return 'Invalid repository name. Please provide Github repository URL or the repository name in the format <ORG/USER_NAME>/<REPO_NAME>.';
+    return 'Invalid repository name. Please provide a Github repository URL or repo name in the format <ORG/USER>/<REPO>.';
   }
 
   public static invalidUrlMessage() {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -173,6 +173,22 @@ export class GithubService {
   }
 
   /**
+   * Checks if the specified organisation exists.
+   * @param orgName - Name of Organisation.
+   */
+  isOrganisationPresent(orgName: string): Observable<boolean> {
+    return from(octokit.orgs.get({ org: orgName, headers: GithubService.IF_NONE_MATCH_EMPTY })).pipe(
+      map((rawData: { status: number }) => {
+        return rawData.status !== ERRORCODE_NOT_FOUND;
+      }),
+      catchError((err) => {
+        return of(false);
+      }),
+      catchError((err) => throwError(ErrorMessageService.organisationNotPresentMessage()))
+    );
+  }
+
+  /**
    * Checks if the specified repository exists.
    * @param owner - Owner of Specified Repository.
    * @param repo - Name of Repository.

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -173,6 +173,21 @@ export class GithubService {
   }
 
   /**
+   * Checks if the specified username exists.
+   * @param userName - Name of Username
+   */
+  isUsernamePresent(userName: string): Observable<boolean> {
+    return from(octokit.users.getByUsername({ username: userName, headers: GithubService.IF_NONE_MATCH_EMPTY })).pipe(
+      map((rawData: { status: number }) => {
+        return rawData.status !== ERRORCODE_NOT_FOUND;
+      }),
+      catchError((err) => {
+        return of(false);
+      })
+    );
+  }
+
+  /**
    * Checks if the specified organisation exists.
    * @param orgName - Name of Organisation.
    */
@@ -183,8 +198,7 @@ export class GithubService {
       }),
       catchError((err) => {
         return of(false);
-      }),
-      catchError((err) => throwError(ErrorMessageService.organisationNotPresentMessage()))
+      })
     );
   }
 
@@ -200,8 +214,7 @@ export class GithubService {
       }),
       catchError((err) => {
         return of(false);
-      }),
-      catchError((err) => throwError(ErrorMessageService.repositoryNotPresentMessage()))
+      })
     );
   }
 

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -113,6 +113,12 @@ export class ViewService {
     this.repoUrlCacheService.cache(repo.toString());
   }
 
+  /**
+   * Verifies if the organisation and repository are present on GitHub.
+   * @param org Organisation name
+   * @param repo Repository name
+   * @returns Promise that resolves to true if the organisation and repository are present.
+   */
   async verifyOrgAndRepo(org: string, repo: string): Promise<boolean> {
     const isValidOrganisation = await this.githubService.isOrganisationPresent(org).toPromise();
     if (!isValidOrganisation) {

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -119,11 +119,11 @@ export class ViewService {
    * @param repo Repository name
    * @returns Promise that resolves to true if the organisation and repository are present.
    */
-  async verifyPrefixAndRepo(org: string, repo: string): Promise<boolean> {
-    const isValidPrefix =
+  async verifyOwnerAndRepo(org: string, repo: string): Promise<boolean> {
+    const isValidOwner =
       (await this.githubService.isOrganisationPresent(org).toPromise()) || (await this.githubService.isUsernamePresent(org).toPromise());
-    if (!isValidPrefix) {
-      throw new Error(ErrorMessageService.repoPrefixNotPresentMessage());
+    if (!isValidOwner) {
+      throw new Error(ErrorMessageService.repoOwnerNotPresentMessage());
     }
 
     const isValidRepository = await this.githubService.isRepositoryPresent(org, repo).toPromise();
@@ -140,7 +140,7 @@ export class ViewService {
    */
   async changeRepositoryIfValid(repo: Repo) {
     this.isChangingRepo.next(true);
-    await this.verifyPrefixAndRepo(repo.owner, repo.name);
+    await this.verifyOwnerAndRepo(repo.owner, repo.name);
     this.changeCurrentRepository(repo);
     this.isChangingRepo.next(false);
   }
@@ -165,7 +165,7 @@ export class ViewService {
     } else {
       repo = new Repo(org, repoName);
     }
-    await this.verifyPrefixAndRepo(repo.owner, repo.name);
+    await this.verifyOwnerAndRepo(repo.owner, repo.name);
     this.logger.info(`ViewService: Repo is ${repo}`);
     this.setRepository(repo);
     this.repoSetSource.next(true);

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -125,11 +125,13 @@ export class ViewService {
       (await this.githubService.isOrganisationPresent(owner).toPromise()) ||
       (await this.githubService.isUsernamePresent(owner).toPromise());
     if (!isValidOwner) {
+      this.isChangingRepo.next(false);
       throw new Error(ErrorMessageService.repoOwnerNotPresentMessage());
     }
 
     const isValidRepository = await this.githubService.isRepositoryPresent(owner, repo).toPromise();
     if (!isValidRepository) {
+      this.isChangingRepo.next(false);
       throw new Error(ErrorMessageService.repositoryNotPresentMessage());
     }
 
@@ -142,13 +144,8 @@ export class ViewService {
    * @throws Error if the repository is not valid
    */
   async changeRepositoryIfValid(repo: Repo) {
-    try {
-      this.isChangingRepo.next(true);
-      await this.verifyOwnerAndRepo(repo.owner, repo.name);
-    } catch (error) {
-      this.isChangingRepo.next(false);
-      throw error;
-    }
+    this.isChangingRepo.next(true);
+    await this.verifyOwnerAndRepo(repo.owner, repo.name);
     this.changeCurrentRepository(repo);
     this.isChangingRepo.next(false);
   }

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -119,10 +119,11 @@ export class ViewService {
    * @param repo Repository name
    * @returns Promise that resolves to true if the organisation and repository are present.
    */
-  async verifyOrgAndRepo(org: string, repo: string): Promise<boolean> {
-    const isValidOrganisation = await this.githubService.isOrganisationPresent(org).toPromise();
-    if (!isValidOrganisation) {
-      throw new Error(ErrorMessageService.organisationNotPresentMessage());
+  async verifyPrefixAndRepo(org: string, repo: string): Promise<boolean> {
+    const isValidPrefix =
+      (await this.githubService.isOrganisationPresent(org).toPromise()) || (await this.githubService.isUsernamePresent(org).toPromise());
+    if (!isValidPrefix) {
+      throw new Error(ErrorMessageService.repoPrefixNotPresentMessage());
     }
 
     const isValidRepository = await this.githubService.isRepositoryPresent(org, repo).toPromise();
@@ -139,7 +140,7 @@ export class ViewService {
    */
   async changeRepositoryIfValid(repo: Repo) {
     this.isChangingRepo.next(true);
-    await this.verifyOrgAndRepo(repo.owner, repo.name);
+    await this.verifyPrefixAndRepo(repo.owner, repo.name);
     this.changeCurrentRepository(repo);
     this.isChangingRepo.next(false);
   }
@@ -164,7 +165,7 @@ export class ViewService {
     } else {
       repo = new Repo(org, repoName);
     }
-    await this.verifyOrgAndRepo(repo.owner, repo.name);
+    await this.verifyPrefixAndRepo(repo.owner, repo.name);
     this.logger.info(`ViewService: Repo is ${repo}`);
     this.setRepository(repo);
     this.repoSetSource.next(true);

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -125,6 +125,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
 
     return (
       this.githubService.isOrganisationPresent(currentRepo.owner) &&
+      this.githubService.isUsernamePresent(currentRepo.owner) &&
       this.githubService.isRepositoryPresent(currentRepo.owner, currentRepo.name)
     );
   }

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -123,7 +123,10 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
       return of(false);
     }
 
-    return this.githubService.isRepositoryPresent(currentRepo.owner, currentRepo.name);
+    return (
+      this.githubService.isOrganisationPresent(currentRepo.owner) &&
+      this.githubService.isRepositoryPresent(currentRepo.owner, currentRepo.name)
+    );
   }
 
   /**

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -124,8 +124,7 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     return (
-      this.githubService.isOrganisationPresent(currentRepo.owner) &&
-      this.githubService.isUsernamePresent(currentRepo.owner) &&
+      (this.githubService.isOrganisationPresent(currentRepo.owner) || this.githubService.isUsernamePresent(currentRepo.owner)) &&
       this.githubService.isRepositoryPresent(currentRepo.owner, currentRepo.name)
     );
   }

--- a/tests/services/view.service.spec.ts
+++ b/tests/services/view.service.spec.ts
@@ -85,7 +85,7 @@ describe('ViewService', () => {
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(false));
 
       await expectAsync(viewService.changeRepositoryIfValid(WATCHER_REPO)).toBeRejectedWithError(
-        ErrorMessageService.repoPrefixNotPresentMessage()
+        ErrorMessageService.repoOwnerNotPresentMessage()
       );
     });
 

--- a/tests/services/view.service.spec.ts
+++ b/tests/services/view.service.spec.ts
@@ -19,7 +19,7 @@ let activatedRouteSpy: jasmine.SpyObj<ActivatedRoute>;
 
 describe('ViewService', () => {
   beforeEach(() => {
-    githubServiceSpy = jasmine.createSpyObj('GithubService', ['isRepositoryPresent', 'storeViewDetails']);
+    githubServiceSpy = jasmine.createSpyObj('GithubService', ['isOrganisationPresent', 'isRepositoryPresent', 'storeViewDetails']);
     activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', ['snapshot']);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     repoUrlCacheServiceSpy = jasmine.createSpyObj('RepoUrlCacheService', ['cache']);
@@ -61,6 +61,7 @@ describe('ViewService', () => {
 
   describe('changeRepositoryIfValid(Repo)', () => {
     it('should set isChangingRepo to true at the start and false at the end', async () => {
+      githubServiceSpy.isOrganisationPresent.and.returnValue(of(true));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(true));
 
       const isChangingRepoNextSpy = spyOn(viewService.isChangingRepo, 'next');
@@ -74,14 +75,16 @@ describe('ViewService', () => {
     });
 
     it('should throw error if repository is not valid', async () => {
+      githubServiceSpy.isOrganisationPresent.and.returnValue(of(false));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(false));
 
       await expectAsync(viewService.changeRepositoryIfValid(WATCHER_REPO)).toBeRejectedWithError(
-        ErrorMessageService.repositoryNotPresentMessage()
+        ErrorMessageService.organisationNotPresentMessage()
       );
     });
 
     it('should set and navigate to new repo if repo is valid', async () => {
+      githubServiceSpy.isOrganisationPresent.and.returnValue(of(true));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(true));
 
       const repoChanged$Spy = spyOn(viewService.repoChanged$, 'next');
@@ -110,6 +113,7 @@ describe('ViewService', () => {
     });
 
     it('should set and navigate to new repo if repo is valid', async () => {
+      githubServiceSpy.isOrganisationPresent.and.returnValue(of(true));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(true));
 
       const repoSetSourceNext = spyOn(viewService.repoSetSource, 'next');
@@ -126,6 +130,7 @@ describe('ViewService', () => {
     });
 
     it('should throw error if repository is invalid', async () => {
+      githubServiceSpy.isOrganisationPresent.and.returnValue(of(true));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(false));
 
       await expectAsync(viewService.initializeCurrentRepository()).toBeRejectedWithError(ErrorMessageService.repositoryNotPresentMessage());

--- a/tests/services/view.service.spec.ts
+++ b/tests/services/view.service.spec.ts
@@ -19,7 +19,12 @@ let activatedRouteSpy: jasmine.SpyObj<ActivatedRoute>;
 
 describe('ViewService', () => {
   beforeEach(() => {
-    githubServiceSpy = jasmine.createSpyObj('GithubService', ['isOrganisationPresent', 'isRepositoryPresent', 'storeViewDetails']);
+    githubServiceSpy = jasmine.createSpyObj('GithubService', [
+      'isUsernamePresent',
+      'isOrganisationPresent',
+      'isRepositoryPresent',
+      'storeViewDetails'
+    ]);
     activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', ['snapshot']);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     repoUrlCacheServiceSpy = jasmine.createSpyObj('RepoUrlCacheService', ['cache']);
@@ -76,10 +81,11 @@ describe('ViewService', () => {
 
     it('should throw error if repository is not valid', async () => {
       githubServiceSpy.isOrganisationPresent.and.returnValue(of(false));
+      githubServiceSpy.isUsernamePresent.and.returnValue(of(false));
       githubServiceSpy.isRepositoryPresent.and.returnValue(of(false));
 
       await expectAsync(viewService.changeRepositoryIfValid(WATCHER_REPO)).toBeRejectedWithError(
-        ErrorMessageService.organisationNotPresentMessage()
+        ErrorMessageService.repoPrefixNotPresentMessage()
       );
     });
 


### PR DESCRIPTION
### Summary:

Fixes #376 

#### Type of change:

- ✨ Enhancement

### Changes Made:

- Added a new error message `repoOwnerNotPresentMessage`, which will show now when the repo owner (i.e. organisation or username) in `OWNER_NAME/REPO` does not exist 
  - originally showed the message `repositoryNotPresentMessage` instead

### Screenshots:

In repo selection page:
![image](https://github.com/CATcher-org/WATcher/assets/53986507/acc563d7-ed79-4c7c-bbaa-fe15a0e7dbae)

After submitting:
![image](https://github.com/CATcher-org/WATcher/assets/53986507/bf3d3802-71e5-4147-9ead-09853a9ad561)

Works for other repo-switching functions as well:
![image](https://github.com/CATcher-org/WATcher/assets/53986507/97f55f61-140b-45a9-a624-919037308dda)
![image](https://github.com/CATcher-org/WATcher/assets/53986507/a13c81e5-e3de-4497-9864-a17a41aedae8)

### Proposed Commit Message:

```
Enhance error message on incorrect organisation/repo name

The original error message for incorrect repo name does not specify 
whether the mistake is in the org name or repo name.

Hence, let's add an additional error message to show if the 
organisation name could not be found. This will give users an easier 
time finding the error and rectifying it when keying in a repo.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [X] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [X] I have updated the project's documentation as necessary.

</details>
