### PR TITLE
Refactor GithubUser model to no longer encapsulate assignee role

### DIFF
--- a/src/app/core/models/assignee.model.ts
+++ b/src/app/core/models/assignee.model.ts
@@ -4,7 +4,7 @@ import { Group } from './github/group.interface';
  * Represents an assignee and its attributes fetched from Github.
  */
 export class Assignee implements Group {
-  static WithoutAssignee: Assignee = new Assignee({ login: 'Issue/PR without an assignee', avatar_url: null });
+  static WithoutAssignee: Assignee = new Assignee({ login: 'Issues/PRs without an assignee', avatar_url: null });
   login: string;
   avatarUrl: string;
 

--- a/src/app/core/models/assignee.model.ts
+++ b/src/app/core/models/assignee.model.ts
@@ -1,0 +1,22 @@
+import { Group } from './github/group.interface';
+
+/**
+ * Represents an assignee and its attributes fetched from Github.
+ */
+export class Assignee implements Group {
+  static WithoutAssignee: Assignee = new Assignee({ login: 'Issue/PR without an assignee', avatar_url: null });
+  login: string;
+  avatarUrl: string;
+
+  constructor(assignee: { login: string; avatar_url: string }) {
+    this.login = assignee.login;
+    this.avatarUrl = assignee.avatar_url;
+  }
+
+  public equals(other: any) {
+    if (!(other instanceof Assignee)) {
+      return false;
+    }
+    return this.login === other.login;
+  }
+}

--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -21,20 +21,6 @@ export interface RawGithubUser {
  * Represents a GitHub user in WATcher
  */
 export class GithubUser implements RawGithubUser {
-  static NO_ASSIGNEE: GithubUser = new GithubUser({
-    avatar_url: '',
-    created_at: '',
-    html_url: '',
-    login: 'Unassigned',
-    name: '',
-    node_id: '',
-    two_factor_authentication: false,
-    site_admin: false,
-    type: '',
-    updated_at: '',
-    url: ''
-  });
-
   avatar_url: string;
   created_at: string;
   html_url: string;

--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -20,7 +20,7 @@ export interface RawGithubUser {
 /**
  * Represents a GitHub user in WATcher
  */
-export class GithubUser implements RawGithubUser, Group {
+export class GithubUser implements RawGithubUser {
   static NO_ASSIGNEE: GithubUser = new GithubUser({
     avatar_url: '',
     created_at: '',

--- a/src/app/core/services/assignee.service.ts
+++ b/src/app/core/services/assignee.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { GithubService } from './github.service';
+import { Assignee } from '../models/assignee.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+/**
+ * Responsible for retrieval and parsing and syncing of assignee data
+ * from the GitHub repository for the WATcher application.
+ */
+export class AssigneeService {
+  assignees: Assignee[] = [];
+  hasNoAssignees: boolean;
+
+  constructor(private githubService: GithubService) {}
+
+  /**
+   * Fetch all assignees from github.
+   */
+  public fetchAssignees(): Observable<any> {
+    return this.githubService.getUsersAssignable().pipe(
+      map((response) => {
+        this.assignees = this.parseAssigneeData(response);
+        this.hasNoAssignees = response.length === 0;
+        return response;
+      })
+    );
+  }
+
+  /**
+   * Parses assignee information and returns an array of Assignee objects.
+   * @param assignees - Assignee Information from API.
+   */
+  parseAssigneeData(assignees: Array<any>): Assignee[] {
+    const assigneeData: Assignee[] = [];
+
+    for (const assignee of assignees) {
+      assigneeData.push(new Assignee(assignee));
+    }
+    assigneeData.sort((a: Assignee, b: Assignee) => a.login.localeCompare(b.login));
+
+    return assigneeData;
+  }
+}

--- a/src/app/core/services/assignee.service.ts
+++ b/src/app/core/services/assignee.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { GithubService } from './github.service';
 import { Assignee } from '../models/assignee.model';
+import { GithubService } from './github.service';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
@@ -5,6 +5,8 @@ import { GithubUser } from '../../models/github-user.model';
 import { Issue } from '../../models/issue.model';
 import { GithubService } from '../github.service';
 import { GroupingStrategy } from './grouping-strategy.interface';
+import { AssigneeService } from '../assignee.service';
+import { Assignee } from '../../models/assignee.model';
 
 /**
  * A GroupingStrategy that groups issues/prs based on their assignees.
@@ -13,30 +15,29 @@ import { GroupingStrategy } from './grouping-strategy.interface';
   providedIn: 'root'
 })
 export class AssigneeGroupingStrategy implements GroupingStrategy {
-  constructor(private githubService: GithubService) {}
+  constructor(private assigneeService: AssigneeService) {}
 
   /**
    * Retrieves data for a specific assignee.
-   * If it is the"No Assignee" group, unassigned issues are returned.
+   * If it is the "No Assignee" group, unassigned issues are returned.
    * Otherwise, issues assigned to the specified user are returned.
    */
-  getDataForGroup(issues: Issue[], key: GithubUser): Issue[] {
-    if (key === GithubUser.NO_ASSIGNEE) {
-      return this.getUnassignedData(issues);
-    }
-
-    return this.getDataAssignedToUser(issues, key);
+  getDataForGroup(issues: Issue[], key: Assignee): Issue[] {
+    return issues.filter(
+      (issue) => issue.assignees.includes(key.login) || (key === Assignee.WithoutAssignee && issue.assignees.length === 0)
+    );
   }
 
   /**
    * Retrieves an Observable emitting users who can be assigned to issues,
    * including a special "No Assignee" option.
    */
-  getGroups(): Observable<GithubUser[]> {
-    return this.githubService.getUsersAssignable().pipe(
-      map((users) => {
-        users.push(GithubUser.NO_ASSIGNEE);
-        return users;
+  getGroups(): Observable<Assignee[]> {
+    return this.assigneeService.fetchAssignees().pipe(
+      map((assignees) => {
+        const parseAssignee = this.assigneeService.parseAssigneeData(assignees);
+        parseAssignee.push(Assignee.WithoutAssignee);
+        return parseAssignee;
       })
     );
   }
@@ -45,21 +46,21 @@ export class AssigneeGroupingStrategy implements GroupingStrategy {
    * Groups other than "No Assignee" need to be shown on the
    * hidden group list if empty.
    */
-  isInHiddenList(group: GithubUser): boolean {
-    return group !== GithubUser.NO_ASSIGNEE;
+  isInHiddenList(group: Assignee): boolean {
+    return group.equals(Assignee.WithoutAssignee);
   }
 
-  private getDataAssignedToUser(issues: Issue[], user: GithubUser): Issue[] {
-    const filteredIssues = issues.filter((issue) => {
-      if (this.isPullRequest(issue)) {
-        return this.isPullRequestCreatedByTarget(issue, user);
-      }
+  // private getDataAssignedToUser(issues: Issue[], user: GithubUser): Issue[] {
+  //   const filteredIssues = issues.filter((issue) => {
+  //     if (this.isPullRequest(issue)) {
+  //       return this.isPullRequestCreatedByTarget(issue, user);
+  //     }
 
-      return this.isIssueAssignedToTarget(issue, user);
-    });
+  //     return this.isIssueAssignedToTarget(issue, user);
+  //   });
 
-    return filteredIssues;
-  }
+  //   return filteredIssues;
+  // }
 
   private getUnassignedData(issues: Issue[]): Issue[] {
     return issues.filter((issue) => !this.isPullRequest(issue) && issue.assignees.length === 0);
@@ -69,11 +70,11 @@ export class AssigneeGroupingStrategy implements GroupingStrategy {
     return issue.issueOrPr === 'PullRequest';
   }
 
-  private isPullRequestCreatedByTarget(issue: Issue, target: GithubUser): boolean {
+  private isPullRequestCreatedByTarget(issue: Issue, target: Assignee): boolean {
     return issue.author === target.login;
   }
 
-  private isIssueAssignedToTarget(issue: Issue, target: GithubUser): boolean {
+  private isIssueAssignedToTarget(issue: Issue, target: Assignee): boolean {
     const isAssigneesFieldDefined = !!issue.assignees;
 
     return isAssigneesFieldDefined && issue.assignees.includes(target.login);

--- a/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Assignee } from '../../models/assignee.model';
 import { GithubUser } from '../../models/github-user.model';
 import { Issue } from '../../models/issue.model';
+import { AssigneeService } from '../assignee.service';
 import { GithubService } from '../github.service';
 import { GroupingStrategy } from './grouping-strategy.interface';
-import { AssigneeService } from '../assignee.service';
-import { Assignee } from '../../models/assignee.model';
 
 /**
  * A GroupingStrategy that groups issues/prs based on their assignees.

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -36,7 +36,7 @@
           mat-card-avatar
           *ngIf="assignee"
           [ngStyle]="{
-            background: 'url(' + assignee.avatar_url + ')',
+            background: 'url(' + assignee.avatarUrl + ')',
             'background-size': '40px'
           }"
         ></div>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -23,7 +23,7 @@
       <div
         mat-card-avatar
         [ngStyle]="{
-          background: 'url(' + assignee.avatar_url + ')',
+          background: 'url(' + assignee.avatarUrl + ')',
           'background-size': '30px'
         }"
       ></div>


### PR DESCRIPTION
### Summary:

This PR is in preparation for the enhancement proposed in the issue #342 

Before this PR, the `GithubUser` model was responsible for storing information for both the authentication as well as details of assignees in each issue/PR. This PR turns them into two separate classes, keeping `GitHubUser` for authentication and moving the details of assignees to a new class `Assignee`.

This is done to ensure separation of roles between models. This will also improve code quality for future PRs related to the role of `Assignees`.

#### Type of change:

- 🎨 Code Refactoring

### Changes Made:

- Created a new model `Assignee`
  - Similar in structure to the existing `Milestone` model
- Replaced all instances where `GithubUser` is used as an assignee with `Assignee`
  - Significant changes were in `assignee-grouping-strategy`, where GithubUser is used heavily as an assignee

### Proposed Commit Message:

```
Refactor GithubUser model to no longer encapsulate assignee role

Currently, GithubUser is responsible for two roles. One, it holds data
for the current user during and after Github authentication. Second, it
stores data for assignees of issues and PRs in the Github repository.

This commit refactors GithubUser to no longer encapsulate the assignee
role. Instead, it introduces a new class, Assignee, to encapsulate
assignee data. 

This change is important to support better cohesion of the components,
and facilitates easier maintenance and further development in both 
functions.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [X] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [X] I have updated the project's documentation as necessary.

</details>
