### PR TITLE
Indicate clickable issue/pr and milestone

### DIFF
--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -9,11 +9,13 @@ export class Milestone implements Group {
   title: string;
   state: string;
   deadline?: Date;
+  number?: number;
 
-  constructor(milestone: { title: string; state: string; due_on?: string }) {
+  constructor(milestone: { title: string; state: string; due_on?: string; number?: string }) {
     this.title = milestone.title;
     this.state = milestone.state;
     this.deadline = milestone.due_on ? new Date(milestone.due_on) : undefined;
+    this.number = milestone.number ? +milestone.number : undefined;
   }
 
   public equals(other: any) {

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -65,7 +65,7 @@ export class ErrorMessageService {
   }
 
   public static unableToOpenMilestoneInBrowserMessage() {
-    return 'Milestone is not assigned';
+    return 'Milestone unassigned';
   }
 
   public static applicationVersionOutdatedMessage() {

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -64,6 +64,10 @@ export class ErrorMessageService {
     return 'Unable to open this issue in Browser';
   }
 
+  public static unableToOpenMilestoneInBrowserMessage() {
+    return 'Unable to open this milestone in Browser';
+  }
+
   public static applicationVersionOutdatedMessage() {
     return 'Please update to the latest version of WATcher.';
   }

--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -65,7 +65,7 @@ export class ErrorMessageService {
   }
 
   public static unableToOpenMilestoneInBrowserMessage() {
-    return 'Unable to open this milestone in Browser';
+    return 'Milestone is not assigned';
   }
 
   public static applicationVersionOutdatedMessage() {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -423,6 +423,15 @@ export class GithubService {
     event.stopPropagation();
   }
 
+  viewMilestoneInBrowser(id: number, event: Event) {
+    if (id) {
+      window.open('https://github.com/'.concat(this.getRepoURL()).concat('/milestone/').concat(String(id)));
+    } else {
+      this.errorHandlingService.handleError(new Error(ErrorMessageService.unableToOpenMilestoneInBrowserMessage()));
+    }
+    event.stopPropagation();
+  }
+
   reset(): void {
     this.logger.info(`GithubService: Resetting issues cache`);
     this.issuesCacheManager.clear();

--- a/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.css
@@ -20,6 +20,7 @@ span.octicon {
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
 :host ::ng-deep .mat-card-header-text {

--- a/src/app/shared/issue-pr-card/issue-pr-card-milestone/issue-pr-card-milestone.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card-milestone/issue-pr-card-milestone.component.css
@@ -9,4 +9,11 @@ span.octicon-milestone {
   margin-bottom: 0px;
   margin-top: 0px;
   align-items: center;
+  transition: box-shadow 0.3s ease-in-out;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.milestone:hover {
+  box-shadow: 2px 2px rgba(160, 160, 160, 0.2);
 }

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -1,11 +1,12 @@
 <mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
-  <a class="no-underline link-grey-dark" (click)="viewIssueInBrowser($event)">
+  <a class="no-underline link-grey-dark">
     <span [matTooltip]="this.issue.updated_at">
-      <app-issue-pr-card-header [issue]="issue"></app-issue-pr-card-header>
+      <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>
       <mat-card-content>
         <app-issue-pr-card-milestone
           [milestone]="issue.milestone"
           [repoHasMilestones]="!milestoneService.hasNoMilestones"
+          (click)="viewMilestoneInBrowser($event)"
         ></app-issue-pr-card-milestone>
         <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
       </mat-card-content>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -3,13 +3,13 @@
     <span [matTooltip]="this.issue.updated_at">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>
     </span>
-    <mat-card-content>
-      <app-issue-pr-card-milestone
-        [milestone]="issue.milestone"
-        [repoHasMilestones]="!milestoneService.hasNoMilestones"
-        (click)="viewMilestoneInBrowser($event)"
-      ></app-issue-pr-card-milestone>
-      <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
-    </mat-card-content>
   </a>
+  <mat-card-content>
+    <app-issue-pr-card-milestone
+      [milestone]="issue.milestone"
+      [repoHasMilestones]="!milestoneService.hasNoMilestones"
+      (click)="viewMilestoneInBrowser($event)"
+    ></app-issue-pr-card-milestone>
+    <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
+  </mat-card-content>
 </mat-card>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -2,14 +2,14 @@
   <a class="no-underline link-grey-dark">
     <span [matTooltip]="this.issue.updated_at">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>
-      <mat-card-content>
-        <app-issue-pr-card-milestone
-          [milestone]="issue.milestone"
-          [repoHasMilestones]="!milestoneService.hasNoMilestones"
-          (click)="viewMilestoneInBrowser($event)"
-        ></app-issue-pr-card-milestone>
-        <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
-      </mat-card-content>
     </span>
+    <mat-card-content>
+      <app-issue-pr-card-milestone
+        [milestone]="issue.milestone"
+        [repoHasMilestones]="!milestoneService.hasNoMilestones"
+        (click)="viewMilestoneInBrowser($event)"
+      ></app-issue-pr-card-milestone>
+      <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
+    </mat-card-content>
   </a>
 </mat-card>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -28,7 +28,7 @@ export class IssuePrCardComponent {
     this.githubService.viewIssueInBrowser(this.issue.id, event);
   }
 
-  /** Opens issue in new window */
+  /** Opens milestone in new window */
   viewMilestoneInBrowser(event: Event) {
     this.logger.info(`CardViewComponent: Opening Milestone ${this.issue.milestone.number} on Github`);
     this.githubService.viewMilestoneInBrowser(this.issue.milestone.number, event);

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -28,6 +28,12 @@ export class IssuePrCardComponent {
     this.githubService.viewIssueInBrowser(this.issue.id, event);
   }
 
+  /** Opens issue in new window */
+  viewMilestoneInBrowser(event: Event) {
+    this.logger.info(`CardViewComponent: Opening Milestone ${this.issue.milestone.number} on Github`);
+    this.githubService.viewMilestoneInBrowser(this.issue.milestone.number, event);
+  }
+
   /** Returns CSS class for border color */
   getIssueOpenOrCloseColorCSSClass() {
     if (this.issue.state === 'OPEN') {

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -17,7 +17,6 @@ import { applySearchFilter } from './search-filter';
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;
   private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
-  private pageChange = new BehaviorSubject(this.paginator.page);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
 
@@ -55,7 +54,7 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
       page = this.paginator.page;
     }
 
-    const displayDataChanges = [this.issueService.issues$, this.pageChange, this.filterChange].filter((x) => x !== undefined);
+    const displayDataChanges = [this.issueService.issues$, page, this.filterChange].filter((x) => x !== undefined);
 
     this.issueService.startPollIssues();
     this.issueSubscription = merge(...displayDataChanges)

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -17,6 +17,7 @@ import { applySearchFilter } from './search-filter';
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;
   private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
+  private pageChange = new BehaviorSubject(this.paginator.page);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
 
@@ -54,7 +55,7 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
       page = this.paginator.page;
     }
 
-    const displayDataChanges = [this.issueService.issues$, page, this.filterChange].filter((x) => x !== undefined);
+    const displayDataChanges = [this.issueService.issues$, this.pageChange, this.filterChange].filter((x) => x !== undefined);
 
     this.issueService.startPollIssues();
     this.issueSubscription = merge(...displayDataChanges)


### PR DESCRIPTION
### Summary:

Fixes #368 

#### Type of change:


- ✨ Enhancement
- 🐛 Bug Fix

### Changes Made:

- Add optional field `number` to `milestone.model`
- Add method `viewMilestoneInBrowser` to handle opening url of milestone
- Set cursor to `pointer` in css
- Add shadow to milestone when hover
- Bind event click to `app-issue-pr-card-header` and `app-issue-pr-card-milestone`

### Screenshots:

![image](https://github.com/CATcher-org/WATcher/assets/108446221/c7db0299-8647-49ce-a1c3-23ca03b3db20)

### Proposed Commit Message:

```
Indicate clickable issue/pr and milestone

Clicking on issue/pr card will link to the issue/pr. Cursor 
indicates text selection when put over issue/pr title and milestone 
title. It should link to different pages when clicked on different 
things on the card and indicate clickable links.

Let's make milestone clickable and make cursor a pointer when put 
over the titles.

```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
