### PR TITLE
Sync items per page to filter change

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -64,7 +64,7 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
     private filtersService: FiltersService,
     private milestoneService: MilestoneService,
     private assigneeService: AssigneeService,
-    private logger: LoggingService,
+    private logger: LoggingService
   ) {}
 
   ngOnInit() {
@@ -82,6 +82,7 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
 
     this.filterSubscription = this.filtersService.filter$.subscribe((filter: any) => {
       this.pageSize = filter.itemsPerPage;
+      this.paginator._changePageSize(this.pageSize);
     });
   }
 


### PR DESCRIPTION
### Summary:

Fixes #366 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change page size of paginator when filter is changed

### Proposed Commit Message:

```
Modify responsiveness of filters to screen size change

When the Items per page count changed, the UI takes some time to 
adjust accordingly. We should make the UI sync right after the change.

Let's update the page size of paginator.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
