### PR TITLE
Fix incorrect assignee filtering  

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -359,4 +359,8 @@ export class FiltersService {
     // TODO Filter out assignees that have not contributed in currently active milestones
     return [...this.assigneeService.assignees, GithubUser.NO_ASSIGNEE];
   }
+
+  getAssignees(): GithubUser[] {
+    return this.assigneeService.assignees.filter((assignee) => this.filter$.value.assignees.includes(assignee.login));
+  }
 }

--- a/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
+++ b/src/app/core/services/grouping/assignee-grouping-strategy.service.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GithubUser } from '../../models/github-user.model';
 import { Issue } from '../../models/issue.model';
+import { FiltersService } from '../filters.service';
 import { GithubService } from '../github.service';
 import { GroupingStrategy } from './grouping-strategy.interface';
 
@@ -13,7 +14,7 @@ import { GroupingStrategy } from './grouping-strategy.interface';
   providedIn: 'root'
 })
 export class AssigneeGroupingStrategy implements GroupingStrategy {
-  constructor(private githubService: GithubService) {}
+  constructor(private githubService: GithubService, private filtersService: FiltersService) {}
 
   /**
    * Retrieves data for a specific assignee.
@@ -45,7 +46,13 @@ export class AssigneeGroupingStrategy implements GroupingStrategy {
    * hidden group list if empty.
    */
   isInHiddenList(group: GithubUser): boolean {
-    return group !== GithubUser.NO_ASSIGNEE;
+    return (
+      group !== GithubUser.NO_ASSIGNEE && // group is not "No Assignee"
+      !this.filtersService
+        .getAssignees()
+        .map((assignee) => assignee.login)
+        .includes(group.login)
+    ); // group is not selected
   }
 
   private getDataAssignedToUser(issues: Issue[], user: GithubUser): Issue[] {

--- a/src/app/core/services/grouping/group.service.ts
+++ b/src/app/core/services/grouping/group.service.ts
@@ -30,7 +30,7 @@ export class GroupService {
   updateHiddenGroups(issueLength: number, target: Group) {
     // If the group is in the hidden list, add it if it has no issues.
     // Also add it if it is unchecked in the filter.
-    if (issueLength === 0 && this.groupingContextService.isInHiddenList(target)) {
+    if (this.groupingContextService.isInHiddenList(target)) {
       this.addToHiddenGroups(target);
     } else {
       this.removeFromHiddenGroups(target);

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -11,7 +11,9 @@
         *ngFor="let group of this.groupService.groups"
         class="issue-table"
         #card
-        [ngStyle]="{ display: card.isLoading || card.issueLength > 0 ? 'initial' : 'none' }"
+        [ngStyle]="{
+          display: card.isLoading || (card.issueLength > 0 && !groupService.hiddenGroups.includes(card.group)) ? 'initial' : 'none'
+        }"
         [group]="group"
         [headers]="this.displayedColumns"
         (issueLengthChange)="this.groupService.updateHiddenGroups($event, group)"

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -88,6 +88,24 @@
         <mat-option [value]="50">50</mat-option>
       </mat-select>
     </mat-form-field>
+    <mat-form-field appearance="standard">
+      <mat-label>Assigned to</mat-label>
+      <mat-select
+        #assigneeSelectorRef
+        [value]="this.filter.assignees"
+        (selectionChange)="this.filtersService.updateFilters({ assignees: $event.value })"
+        [disabled]="this.assigneeService.hasNoAssignees"
+        multiple
+      >
+        <mat-select-trigger *ngIf="this.assigneeService.hasNoAssignees">
+          <span>No Assignees</span>
+        </mat-select-trigger>
+        <mat-option *ngFor="let assignee of this.assigneeService.assignees" [value]="assignee.login">
+          {{ assignee.login }}
+        </mat-option>
+        <mat-option [value]="'Unassigned'">Unassigned</mat-option>
+      </mat-select>
+    </mat-form-field>
     <app-label-filter-bar></app-label-filter-bar>
   </li>
   <li class="menu" (click)="toggleMenu()">


### PR DESCRIPTION
### Summary:
Fixes bug #385 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:
Assignee filter now correctly removes Assignee columns when it is not selected in the filter:
![image](https://github.com/user-attachments/assets/a34a8cae-f214-4ad1-91d8-451216809a34)

### Proposed Commit Message:

```
Fix incorrect filtering of issues with multiple assignees

Previously, the application will sometimes display additional assignees
which were not selected in the assignee filter.

Let's fix this bug and ensure that the application only shows for 
assignees selected in the assignee filter.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
