### PR TITLE
Show issues and PRs without milestones in 'Contributions' preset view

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -66,7 +66,7 @@ export class FiltersService {
       type: 'all',
       sort: { active: 'id', direction: 'desc' },
       labels: [],
-      milestones: this.milestoneService.milestones.map((milestone) => milestone.title),
+      milestones: this.getMilestonesForContributions().map((milestone) => milestone.title),
       deselectedLabels: new Set<string>(),
       itemsPerPage: 20,
       assignees: this.assigneeService.assignees.map((assignee) => assignee.login)
@@ -358,5 +358,10 @@ export class FiltersService {
   getAssigneesForCurrentlyActive(): GithubUser[] {
     // TODO Filter out assignees that have not contributed in currently active milestones
     return [...this.assigneeService.assignees, GithubUser.NO_ASSIGNEE];
+  }
+
+  getMilestonesForContributions(): Milestone[] {
+    const milestones = this.milestoneService.milestones;
+    return [...milestones, Milestone.PRWithoutMilestone, Milestone.IssueWithoutMilestone];
   }
 }


### PR DESCRIPTION
### Summary:

Fixes #369 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Changed 'Contributions' preset view to include issues and PRs without a milestone

### Screenshots:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/22a4e97c-7ecd-4e5e-9d47-017ef0ee1a08" />

### Proposed Commit Message:

```
Include issues/PRs without milestones in 'Contributions' preset view

The 'Contributions' preset view doesn't include issues/PRs without a milestone.

However, issues and PRs without milestones are contributions as well, and should
be included in the 'Contributions' preset view.

Let's show issues and PRs without milestones in the 'Contributions' preset view as well.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
