### PR TITLE
Solve Github Actions failing for macos-setup-and-tests

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install --legacy-peer-deps
-      - run: npm update
+      - run: npm update --legacy-peer-deps
       - run: npm run lint
       - run: npm run build:prod:web
       - run: npm run test
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install --legacy-peer-deps
-      - run: npm update
+      - run: npm update --legacy-peer-deps
       - run: npm run lint
       - run: npm run test
     # - run: npm test -- "--karma-config=./tests/karma.ci.conf.js" || npm test -- "--karma-config=./tests/karma.ci.conf.js"
@@ -61,7 +61,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install --legacy-peer-deps
-      - run: npm update
+      - run: npm update --legacy-peer-deps
       - run: npm run lint
       - run: npm run test
     # - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -36,35 +36,24 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-
-          arch -x86_64 /bin/bash -c "
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            source ~/.bashrc
-            nvm install 14
-          "
-
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
-          nvm use 14
-          npm install
-          npm update
-          npm run lint
-          npm run test
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm update
+      - run: npm run lint
+      - run: npm run test
     # - run: npm test -- "--karma-config=./tests/karma.ci.conf.js" || npm test -- "--karma-config=./tests/karma.ci.conf.js"
     # retry tests once, in case they timed out on Mac OS
   windows-setup-and-tests:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -40,13 +40,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm update
-      - run: npm run lint
-      - run: npm run test
+        run: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+          arch -x86_64 /bin/bash -c "
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            source ~/.bashrc
+            nvm install 14
+          "
+
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+          nvm use 14
+          npm install
+          npm update
+          npm run lint
+          npm run test
     # - run: npm test -- "--karma-config=./tests/karma.ci.conf.js" || npm test -- "--karma-config=./tests/karma.ci.conf.js"
     # retry tests once, in case they timed out on Mac OS
   windows-setup-and-tests:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm update
       - run: npm run lint
       - run: npm run build:prod:web
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm update
       - run: npm run lint
       - run: npm run test
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm update
       - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
### Summary:

Fixes #390 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Change node version to 16.x
- Add --legacy-peer-deps flag to `npm install` and `npm update`

### Proposed Commit Message:

```
Solve Github Actions failing for macos-setup-and-tests

The macos-setup-and-tests action is failing. This is because the 
setup-node Github action on macos-latest attempts to install the darwin 
arm64 version of node 14.x, which does not exist.

This causes the setup-node Github action to fail for macos-latest.

Let's change the workflow to use node version 16.x.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
