### PR TITLE
Remove magic strings

### DIFF
--- a/src/app/core/constants/filter-options.constants.ts
+++ b/src/app/core/constants/filter-options.constants.ts
@@ -26,5 +26,5 @@ export enum OrderOptions {
 
 export enum MilestoneOptions {
   IssueWithoutMilestone = 'Issue without a milestone',
-  PullRequestWithoutMilestone = 'Pull Request without a milestone'
+  PullRequestWithoutMilestone = 'PR without a milestone'
 }

--- a/src/app/core/constants/filter-options.constants.ts
+++ b/src/app/core/constants/filter-options.constants.ts
@@ -1,0 +1,30 @@
+export enum StatusOptions {
+  OpenPullRequests = 'open pullrequest',
+  MergedPullRequests = 'merged pullrequest',
+  ClosedPullRequests = 'closed pullrequest',
+  OpenIssues = 'open issue',
+  ClosedIssues = 'closed issue'
+}
+
+export enum TypeOptions {
+  All = 'all',
+  Issue = 'issue',
+  PullRequests = 'pullrequest'
+}
+
+export enum SortOptions {
+  Id = 'id',
+  Title = 'title',
+  Date = 'date',
+  Status = 'status'
+}
+
+export enum OrderOptions {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export enum MilestoneOptions {
+  IssueWithoutMilestone = 'Issue without a milestone',
+  PullRequestWithoutMilestone = 'Pull Request without a milestone'
+}

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -8,6 +8,7 @@ import { Milestone } from '../models/milestone.model';
 import { AssigneeService } from './assignee.service';
 import { LoggingService } from './logging.service';
 import { MilestoneService } from './milestone.service';
+import { StatusOptions, TypeOptions, SortOptions, OrderOptions } from '../constants/filter-options.constants';
 
 export type Filter = {
   title: string;
@@ -35,9 +36,9 @@ export class FiltersService {
 
   readonly defaultFilter: Filter = {
     title: '',
-    status: ['open pullrequest', 'merged pullrequest', 'open issue', 'closed issue'],
-    type: 'all',
-    sort: { active: 'status', direction: 'asc' },
+    status: [StatusOptions.OpenPullRequests, StatusOptions.MergedPullRequests, StatusOptions.OpenIssues, StatusOptions.ClosedIssues],
+    type: TypeOptions.All,
+    sort: { active: SortOptions.Status, direction: OrderOptions.Asc },
     labels: [],
     milestones: [],
     hiddenLabels: new Set<string>(),
@@ -51,9 +52,9 @@ export class FiltersService {
   } = {
     currentlyActive: () => ({
       title: '',
-      status: ['open pullrequest', 'merged pullrequest', 'open issue', 'closed issue'],
-      type: 'all',
-      sort: { active: 'status', direction: 'asc' },
+      status: [StatusOptions.OpenPullRequests, StatusOptions.MergedPullRequests, StatusOptions.OpenIssues, StatusOptions.ClosedIssues],
+      type: TypeOptions.All,
+      sort: { active: SortOptions.Status, direction: OrderOptions.Asc },
       labels: [],
       milestones: this.getMilestonesForCurrentlyActive().map((milestone) => milestone.title),
       deselectedLabels: new Set<string>(),
@@ -62,9 +63,9 @@ export class FiltersService {
     }),
     contributions: () => ({
       title: '',
-      status: ['open pullrequest', 'merged pullrequest', 'open issue', 'closed issue'],
-      type: 'all',
-      sort: { active: 'id', direction: 'desc' },
+      status: [StatusOptions.OpenPullRequests, StatusOptions.MergedPullRequests, StatusOptions.OpenIssues, StatusOptions.ClosedIssues],
+      type: TypeOptions.All,
+      sort: { active: SortOptions.Status, direction: OrderOptions.Asc },
       labels: [],
       milestones: this.milestoneService.milestones.map((milestone) => milestone.title),
       deselectedLabels: new Set<string>(),
@@ -358,5 +359,9 @@ export class FiltersService {
   getAssigneesForCurrentlyActive(): GithubUser[] {
     // TODO Filter out assignees that have not contributed in currently active milestones
     return [...this.assigneeService.assignees, GithubUser.NO_ASSIGNEE];
+  }
+
+  getFilter(): Filter {
+    return this.filter$.value;
   }
 }

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -2,13 +2,13 @@ import { Injectable } from '@angular/core';
 import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, pipe } from 'rxjs';
+import { OrderOptions, SortOptions, StatusOptions, TypeOptions } from '../constants/filter-options.constants';
 import { GithubUser } from '../models/github-user.model';
 import { SimpleLabel } from '../models/label.model';
 import { Milestone } from '../models/milestone.model';
 import { AssigneeService } from './assignee.service';
 import { LoggingService } from './logging.service';
 import { MilestoneService } from './milestone.service';
-import { StatusOptions, TypeOptions, SortOptions, OrderOptions } from '../constants/filter-options.constants';
 
 export type Filter = {
   title: string;
@@ -65,7 +65,7 @@ export class FiltersService {
       title: '',
       status: [StatusOptions.OpenPullRequests, StatusOptions.MergedPullRequests, StatusOptions.OpenIssues, StatusOptions.ClosedIssues],
       type: TypeOptions.All,
-      sort: { active: SortOptions.Status, direction: OrderOptions.Asc },
+      sort: { active: SortOptions.Id, direction: OrderOptions.Desc },
       labels: [],
       milestones: this.milestoneService.milestones.map((milestone) => milestone.title),
       deselectedLabels: new Set<string>(),

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -23,19 +23,19 @@
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Status</mat-label>
       <mat-select [value]="this.filter.status" (selectionChange)="this.filtersService.updateFilters({ status: $event.value })" multiple>
-        <mat-option *ngIf="isFilterPullRequest()" value="open pullrequest">Open Pull Requests</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" value="merged pullrequest">Merged Pull Requests</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" value="closed pullrequest">Closed Pull Request</mat-option>
-        <mat-option *ngIf="isFilterIssue()" value="open issue">Open Issues</mat-option>
-        <mat-option *ngIf="isFilterIssue()" value="closed issue">Closed Issues</mat-option>
+        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.OpenPullRequests">Open Pull Requests</mat-option>
+        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.MergedPullRequests">Merged Pull Requests</mat-option>
+        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.ClosedPullRequests">Closed Pull Request</mat-option>
+        <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.OpenIssues">Open Issues</mat-option>
+        <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.ClosedIssues">Closed Issues</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Type</mat-label>
       <mat-select [value]="this.filter.type" (selectionChange)="this.filtersService.updateFilters({ type: $event.value })">
-        <mat-option value="all">All</mat-option>
-        <mat-option value="issue">Issue</mat-option>
-        <mat-option value="pullrequest">Pull Request</mat-option>
+        <mat-option [value]="typeOptions.All">All</mat-option>
+        <mat-option [value]="typeOptions.Issue">Issue</mat-option>
+        <mat-option [value]="typeOptions.PullRequests">Pull Request</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-form-field
@@ -47,16 +47,16 @@
     >
       <mat-label>Sort</mat-label>
       <mat-select [value]="this.filter.sort.active">
-        <mat-option value="id">
+        <mat-option [value]="sortOptions.Id">
           <span mat-sort-header="id">ID</span>
         </mat-option>
-        <mat-option value="title">
+        <mat-option [value]="sortOptions.Title">
           <span mat-sort-header="title">Title</span>
         </mat-option>
-        <mat-option value="date">
+        <mat-option [value]="sortOptions.Date">
           <span mat-sort-header="date">Date Updated</span>
         </mat-option>
-        <mat-option value="status">
+        <mat-option [value]="sortOptions.Status">
           <span mat-sort-header="status">Status</span>
         </mat-option>
       </mat-select>
@@ -76,8 +76,10 @@
         <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.title">
           {{ milestone.title }}
         </mat-option>
-        <mat-option *ngIf="isFilterIssue()" [value]="'Issue without a milestone'">Issues without a milestone</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" [value]="'PR without a milestone'">PRs without a milestone</mat-option>
+        <mat-option *ngIf="isFilterIssue()" [value]="milestoneOptions.IssueWithoutMilestone">Issues without a milestone</mat-option>
+        <mat-option *ngIf="isFilterPullRequest()" [value]="milestoneOptions.PullRequestWithoutMilestone"
+          >PRs without a milestone</mat-option
+        >
       </mat-select>
     </mat-form-field>
     <mat-form-field appearance="standard" class="filter-item">

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnDestroy, OnInit, QueryList, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit, QueryList, Type, ViewChild } from '@angular/core';
 import { MatSelect } from '@angular/material/select';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { AssigneeService } from '../../core/services/assignee.service';
@@ -9,6 +9,7 @@ import { MilestoneService } from '../../core/services/milestone.service';
 import { ViewService } from '../../core/services/view.service';
 import { FilterableComponent } from '../issue-tables/filterableTypes';
 import { LabelFilterBarComponent } from './label-filter-bar/label-filter-bar.component';
+import { StatusOptions, TypeOptions, SortOptions, MilestoneOptions } from '../../core/constants/filter-options.constants';
 
 /**
  * This component is abstracted out filterbar used by both detailed-viewer page
@@ -30,6 +31,11 @@ export class FilterBarComponent implements OnInit, OnDestroy {
   groupByEnum: typeof GroupBy = GroupBy;
 
   isMenuOpen = false;
+
+  statusOptions = StatusOptions;
+  typeOptions = TypeOptions;
+  sortOptions = SortOptions;
+  milestoneOptions = MilestoneOptions;
 
   /** Milestone subscription */
   milestoneSubscription: Subscription;
@@ -79,11 +85,11 @@ export class FilterBarComponent implements OnInit, OnDestroy {
    * Checks if program is filtering by type issue.
    */
   isFilterIssue() {
-    return this.filter.type === 'issue' || this.filter.type === 'all';
+    return this.filter.type === this.typeOptions.Issue || this.filter.type === this.typeOptions.All;
   }
 
   isFilterPullRequest() {
-    return this.filter.type === 'pullrequest' || this.filter.type === 'all';
+    return this.filter.type === this.typeOptions.PullRequests || this.filter.type === this.typeOptions.All;
   }
 
   /**

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, Input, OnDestroy, OnInit, QueryList, Type, ViewChild } from '@angular/core';
 import { MatSelect } from '@angular/material/select';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import { MilestoneOptions, SortOptions, StatusOptions, TypeOptions } from '../../core/constants/filter-options.constants';
 import { AssigneeService } from '../../core/services/assignee.service';
 import { Filter, FiltersService } from '../../core/services/filters.service';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
@@ -9,7 +10,6 @@ import { MilestoneService } from '../../core/services/milestone.service';
 import { ViewService } from '../../core/services/view.service';
 import { FilterableComponent } from '../issue-tables/filterableTypes';
 import { LabelFilterBarComponent } from './label-filter-bar/label-filter-bar.component';
-import { StatusOptions, TypeOptions, SortOptions, MilestoneOptions } from '../../core/constants/filter-options.constants';
 
 /**
  * This component is abstracted out filterbar used by both detailed-viewer page

--- a/tests/constants/filter.constants.ts
+++ b/tests/constants/filter.constants.ts
@@ -1,12 +1,19 @@
+import {
+  MilestoneOptions,
+  OrderOptions,
+  SortOptions,
+  StatusOptions,
+  TypeOptions
+} from '../../src/app/core/constants/filter-options.constants';
 import { Filter } from '../../src/app/core/services/filters.service';
 
 export const DEFAULT_FILTER: Filter = {
   title: '',
-  status: ['open pullrequest', 'merged pullrequest', 'open issue', 'closed issue'],
-  type: 'all',
-  sort: { active: 'status', direction: 'asc' },
+  status: [StatusOptions.OpenPullRequests, StatusOptions.MergedPullRequests, StatusOptions.OpenIssues, StatusOptions.ClosedIssues],
+  type: TypeOptions.All,
+  sort: { active: SortOptions.Status, direction: OrderOptions.Asc },
   labels: [],
-  milestones: ['PR without a milestone'],
+  milestones: [MilestoneOptions.PullRequestWithoutMilestone],
   hiddenLabels: new Set<string>(),
   deselectedLabels: new Set<string>(),
   itemsPerPage: 20,
@@ -15,9 +22,9 @@ export const DEFAULT_FILTER: Filter = {
 
 export const CHANGED_FILTER: Filter = {
   title: 'test',
-  status: ['open pullrequest'],
-  type: 'issue',
-  sort: { active: 'id', direction: 'asc' },
+  status: [StatusOptions.OpenPullRequests],
+  type: TypeOptions.Issue,
+  sort: { active: SortOptions.Id, direction: OrderOptions.Asc },
   labels: ['aspect-testing', 'aspect-documentation'],
   milestones: ['V3.3.6'],
   hiddenLabels: new Set<string>(['aspect-testing']),


### PR DESCRIPTION
### Summary:

Fixes #399 

#### Type of change:

- 🎨 Code Refactoring

### Changes Made:

- Moved magic strings from filter options into enum constants

### Screenshots:

![image](https://github.com/user-attachments/assets/aaecca94-3f9e-4b69-af53-0f372862dcf4)
![image](https://github.com/user-attachments/assets/6bc4f861-236d-42ca-965d-0b3c86b7e2a9)

### Proposed Commit Message:

```
Remove the use of magic strings for filter options

All of the predefined filter options values are magic literals. This
makes it hard to change or update any filter options without having
to change all manually.

Let's create enums constants with the same values to replace the
magic literals.

The enums constants will also allow us to create mappings for URL
encoding dynamically.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
