### PR TITLE
Remove repo from suggestions if invalid

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -256,7 +256,6 @@ export class AuthService {
       }),
       catchError((error) => {
         this.errorHandlingService.handleError(error);
-        // Remove from local storage
         this.clearNext();
         return of(false);
       })

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -256,6 +256,7 @@ export class AuthService {
       }),
       catchError((error) => {
         this.errorHandlingService.handleError(error);
+        // Remove from local storage
         this.clearNext();
         return of(false);
       })

--- a/src/app/core/services/repo-url-cache.service.ts
+++ b/src/app/core/services/repo-url-cache.service.ts
@@ -25,6 +25,9 @@ export class RepoUrlCacheService {
 
   removeFromSuggestions(repo: string): void {
     const repoIndex = this.suggestions.indexOf(repo);
+    if (repoIndex == -1) {
+      return;
+    }
     this.suggestions.splice(repoIndex, 1);
     window.localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify(this.suggestions));
   }

--- a/src/app/core/services/repo-url-cache.service.ts
+++ b/src/app/core/services/repo-url-cache.service.ts
@@ -24,11 +24,7 @@ export class RepoUrlCacheService {
   }
 
   removeFromSuggestions(repo: string): void {
-    const repoIndex = this.suggestions.indexOf(repo);
-    if (repoIndex === -1) {
-      return;
-    }
-    this.suggestions.splice(repoIndex, 1);
+    this.suggestions = this.suggestions.filter(r => r !== repo);
     window.localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify(this.suggestions));
   }
 

--- a/src/app/core/services/repo-url-cache.service.ts
+++ b/src/app/core/services/repo-url-cache.service.ts
@@ -25,7 +25,7 @@ export class RepoUrlCacheService {
 
   removeFromSuggestions(repo: string): void {
     const repoIndex = this.suggestions.indexOf(repo);
-    if (repoIndex == -1) {
+    if (repoIndex === -1) {
       return;
     }
     this.suggestions.splice(repoIndex, 1);

--- a/src/app/core/services/repo-url-cache.service.ts
+++ b/src/app/core/services/repo-url-cache.service.ts
@@ -23,7 +23,7 @@ export class RepoUrlCacheService {
     }
   }
 
-  removeFromSuggetions(repo: string): void {
+  removeFromSuggestions(repo: string): void {
     const repoIndex = this.suggestions.indexOf(repo);
     this.suggestions.splice(repoIndex, 1);
     window.localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify(this.suggestions));

--- a/src/app/core/services/repo-url-cache.service.ts
+++ b/src/app/core/services/repo-url-cache.service.ts
@@ -23,6 +23,12 @@ export class RepoUrlCacheService {
     }
   }
 
+  removeFromSuggetions(repo: string): void {
+    const repoIndex = this.suggestions.indexOf(repo);
+    this.suggestions.splice(repoIndex, 1);
+    window.localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify(this.suggestions));
+  }
+
   getFilteredSuggestions(control: AbstractControl): Observable<string[]> {
     // Ref: https://v10.material.angular.io/components/autocomplete/overview
     return control.valueChanges.pipe(

--- a/src/app/core/services/view.service.ts
+++ b/src/app/core/services/view.service.ts
@@ -132,6 +132,7 @@ export class ViewService {
     const isValidRepository = await this.githubService.isRepositoryPresent(owner, repo).toPromise();
     if (!isValidRepository) {
       this.isChangingRepo.next(false);
+      this.repoUrlCacheService.removeFromSuggestions(owner + '/' + repo);
       throw new Error(ErrorMessageService.repositoryNotPresentMessage());
     }
 

--- a/tests/services/repo-url-cache.service.spec.ts
+++ b/tests/services/repo-url-cache.service.spec.ts
@@ -76,4 +76,21 @@ describe('RepoUrlCacheService', () => {
       expect(filteredSuggestions).toBeInstanceOf(Observable);
     });
   });
+
+  describe('removeFromSuggestions()', () => {
+    it('should return without changing anything if repo is not in localStorage', () => {
+      localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify([repoNameOne]));
+      repoUrlCacheService = new RepoUrlCacheService();
+      const oldSuggestions = localStorage.getItem(RepoUrlCacheService.KEY_NAME);
+      repoUrlCacheService.removeFromSuggestions(repoNameTwo);
+      expect(localStorage.getItem(RepoUrlCacheService.KEY_NAME)).toEqual(oldSuggestions);
+    });
+
+    it('should be able to remove a repo if it is in localStorage', () => {
+      localStorage.setItem(RepoUrlCacheService.KEY_NAME, JSON.stringify([repoNameOne, repoNameTwo]));
+      repoUrlCacheService = new RepoUrlCacheService();
+      repoUrlCacheService.removeFromSuggestions(repoNameTwo);
+      expect(localStorage.getItem(RepoUrlCacheService.KEY_NAME)).toEqual(JSON.stringify([repoNameOne]));
+    });
+  });
 });

--- a/tests/services/view.service.spec.ts
+++ b/tests/services/view.service.spec.ts
@@ -27,7 +27,7 @@ describe('ViewService', () => {
     ]);
     activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', ['snapshot']);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-    repoUrlCacheServiceSpy = jasmine.createSpyObj('RepoUrlCacheService', ['cache']);
+    repoUrlCacheServiceSpy = jasmine.createSpyObj('RepoUrlCacheService', ['cache', 'removeFromSuggestions']);
     loggingServiceSpy = jasmine.createSpyObj('LoggingService', ['info']);
     viewService = new ViewService(githubServiceSpy, repoUrlCacheServiceSpy, loggingServiceSpy, activatedRouteSpy, routerSpy);
   });


### PR DESCRIPTION
### Summary:

Fixes #397 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Removed a repo from suggestions if it is not a valid repo
- Edited spy object in testing to include new function

### Proposed Commit Message:

```
Remove repo from suggestions if invalid

WATcher does not remove a repo from suggestions if it is not valid. 
This results in invalid repositories shown under suggestions if 
the user has previously entered one. 

Let's remove invalid repos from suggestions since users do not need 
to choose them.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
