### PR TITLE
Handle templates using BehaviorSubject and async pipe

### DIFF
--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -5,7 +5,11 @@
   </mat-card>
   <div class="scrollable-container">
     <div *ngFor="let group of groups">
-      <ng-container [ngTemplateOutlet]="getCardTemplate()" [ngTemplateOutletContext]="{ $implicit: group }"></ng-container>
+      <ng-container
+        *ngIf="currentCardTemplate$ | async as template"
+        [ngTemplateOutlet]="template"
+        [ngTemplateOutletContext]="{ $implicit: group }"
+      ></ng-container>
     </div>
   </div>
 </div>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,5 +1,5 @@
+import { AfterViewInit, Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { Group } from '../../core/models/github/group.interface';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
 
@@ -8,7 +8,7 @@ import { GroupBy, GroupingContextService } from '../../core/services/grouping/gr
   templateUrl: './hidden-groups.component.html',
   styleUrls: ['./hidden-groups.component.css']
 })
-export class HiddenGroupsComponent {
+export class HiddenGroupsComponent implements AfterViewInit {
   @Input() groups: Group[] = [];
 
   @ViewChild('defaultCard') defaultCardTemplate: TemplateRef<any>;

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,7 +1,7 @@
+import { BehaviorSubject } from 'rxjs';
 import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { Group } from '../../core/models/github/group.interface';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
-import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'app-hidden-groups',

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { Group } from '../../core/models/github/group.interface';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'app-hidden-groups',
@@ -14,7 +15,15 @@ export class HiddenGroupsComponent {
   @ViewChild('assigneeCard') assigneeCardTemplate: TemplateRef<any>;
   @ViewChild('milestoneCard') milestoneCardTemplate: TemplateRef<any>;
 
+  private currentCardTemplate$ = new BehaviorSubject<TemplateRef<any>>(null);
+
   constructor(public groupingContextService: GroupingContextService) {}
+
+  ngAfterViewInit() {
+    setTimeout(() => {
+      this.currentCardTemplate$.next(this.getCardTemplate());
+    });
+  }
 
   getCardTemplate(): TemplateRef<any> {
     switch (this.groupingContextService.currGroupBy) {


### PR DESCRIPTION
### Summary:

Fixes #406 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Created a new BehaviorSubject with an initial value of null in hidden-groups.component.ts to emit a value for the card template to be shown after the view has been initialized.
- `setTimeout()` is used to defer the `.next()` function to after the current change detection cycle finishes.

### Proposed Commit Message:

```
Handle templates using BehaviorSubject and async pipe

There is an error that appears when switching to an invalid repo. 
In the hidden-groups component, the templates are undefined before 
the view is initialized and they become defined afterwards, 
causing an NG0100 error. 

Let's use a BehaviorSubject with an initial value of null to emit the 
card template after the view has been initialized and use the async 
pipe so that the error does not occur.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
