### PR TITLE
Fix incorrect behaviour when filtering by assignee in issues with multiple assignees

### DIFF
--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -52,9 +52,9 @@ export class GithubUser implements RawGithubUser, Group {
     Object.assign(this, rawData);
   }
 
-  /* 
-  This method is used to enable comparisons between 
-  a Group and the filtering criteria, which is stored 
+  /*
+  This method is used to enable comparisons between
+  a Group and the filtering criteria, which is stored
   as a string, in IssuesDataTable.ts
   */
   static fromUsername(username: string) {

--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -52,6 +52,11 @@ export class GithubUser implements RawGithubUser, Group {
     Object.assign(this, rawData);
   }
 
+  /* 
+  This method is used to enable comparisons between 
+  a Group and the filtering criteria, which is stored 
+  as a string, in IssuesDataTable.ts
+  */
   static fromUsername(username: string) {
     return new GithubUser({
       login: username,

--- a/src/app/core/models/github-user.model.ts
+++ b/src/app/core/models/github-user.model.ts
@@ -52,6 +52,22 @@ export class GithubUser implements RawGithubUser, Group {
     Object.assign(this, rawData);
   }
 
+  static fromUsername(username: string) {
+    return new GithubUser({
+      login: username,
+      avatar_url: '',
+      created_at: '',
+      html_url: '',
+      name: '',
+      node_id: '',
+      two_factor_authentication: false,
+      site_admin: false,
+      type: '',
+      updated_at: '',
+      url: ''
+    });
+  }
+
   equals(other: any) {
     if (!(other instanceof GithubUser)) {
       return false;

--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -18,6 +18,10 @@ export class Milestone implements Group {
     this.number = milestone.number ? +milestone.number : undefined;
   }
 
+  static fromTitle(title: string): Milestone {
+    return new Milestone({ title, state: '' });
+  }
+
   public equals(other: any) {
     if (!(other instanceof Milestone)) {
       return false;

--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -18,6 +18,11 @@ export class Milestone implements Group {
     this.number = milestone.number ? +milestone.number : undefined;
   }
 
+  /* 
+  This method is used to enable comparisons between 
+  a Group and the filtering criteria, which is stored 
+  as a string, in IssuesDataTable.ts
+  */
   static fromTitle(title: string): Milestone {
     return new Milestone({ title, state: '' });
   }

--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -18,9 +18,9 @@ export class Milestone implements Group {
     this.number = milestone.number ? +milestone.number : undefined;
   }
 
-  /* 
-  This method is used to enable comparisons between 
-  a Group and the filtering criteria, which is stored 
+  /*
+  This method is used to enable comparisons between
+  a Group and the filtering criteria, which is stored
   as a string, in IssuesDataTable.ts
   */
   static fromTitle(title: string): Milestone {

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -2,8 +2,10 @@ import { DataSource } from '@angular/cdk/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { BehaviorSubject, merge, Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { GithubUser } from '../../core/models/github-user.model';
 import { Group } from '../../core/models/github/group.interface';
 import { Issue } from '../../core/models/issue.model';
+import { Milestone } from '../../core/models/milestone.model';
 import { AssigneeService } from '../../core/services/assignee.service';
 import { Filter, FiltersService } from '../../core/services/filters.service';
 import { GroupingContextService } from '../../core/services/grouping/grouping-context.service';
@@ -14,8 +16,6 @@ import { FilterableSource } from './filterableTypes';
 import { paginateData } from './issue-paginator';
 import { applySort } from './issue-sorter';
 import { applySearchFilter } from './search-filter';
-import { GithubUser } from '../../core/models/github-user.model';
-import { Milestone } from '../../core/models/milestone.model';
 
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -77,11 +77,12 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
             groupFilterAsGithubUser.filter((githubUser) => this.group?.equals(githubUser)).length !== 0 ||
             groupFilterAsMilestone.filter((milestone) => this.group?.equals(milestone)).length !== 0;
 
-          let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
-
           if (!isGroupInFilter) {
-            data = [];
+            this.count = 0;
+            return [];
           }
+
+          let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
 
           if (this.defaultFilter) {
             data = data.filter(this.defaultFilter);

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -25,6 +25,21 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
 
   public isLoading$ = this.issueService.isLoading.asObservable();
 
+  private static isGroupInFilter(group: Group, filter: Filter): boolean {
+    const groupFilterAsGithubUser = filter.assignees.map((selectedAssignee) => {
+      return GithubUser.fromUsername(selectedAssignee);
+    });
+    const groupFilterAsMilestone = filter.milestones.map((selectedMilestone) => {
+      return Milestone.fromTitle(selectedMilestone);
+    });
+
+    const isGroupInFilter =
+      groupFilterAsGithubUser.some((githubUser) => group?.equals(githubUser)) ||
+      groupFilterAsMilestone.some((milestone) => group?.equals(milestone));
+
+    return isGroupInFilter;
+  }
+
   constructor(
     private issueService: IssueService,
     private groupingContextService: GroupingContextService,
@@ -50,21 +65,6 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
       this.issueSubscription.unsubscribe();
     }
     this.issueService.stopPollIssues();
-  }
-
-  private static isGroupInFilter(group: Group, filter: Filter): boolean {
-    const groupFilterAsGithubUser = filter.assignees.map((selectedAssignee) => {
-      return GithubUser.fromUsername(selectedAssignee);
-    });
-    const groupFilterAsMilestone = filter.milestones.map((selectedMilestone) => {
-      return Milestone.fromTitle(selectedMilestone);
-    });
-
-    const isGroupInFilter =
-      groupFilterAsGithubUser.some((githubUser) => group?.equals(githubUser)) ||
-      groupFilterAsMilestone.some((milestone) => group?.equals(milestone));
-
-    return isGroupInFilter;
   }
 
   loadIssues() {


### PR DESCRIPTION
### Summary:

Fixes #385 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Following @Eclipse-Dominator 's  [comments](https://github.com/CATcher-org/WATcher/pull/389#pullrequestreview-2589433090) on #389, added a check for if the group is found in the filters in `IssueDataTable`.

### Screenshots:

https://github.com/user-attachments/assets/efcb9f87-0f1b-4c26-a244-573815262385

### Proposed Commit Message:

```
Hide assignees not selected in filter

For issues with multiple assignees, having one of the assignees selected
in the filter displays all other assignees as groups.

This is misleading behaviour since the assignees that are not selected
are expected to be hidden.

Let's add a check for if the group is selected in the filter before
displaying the data.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
