### PR TITLE
Align remove all button to expectations of function

### DIFF
--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -13,7 +13,7 @@
       <input #input matInput placeholder="Find labels" />
     </mat-form-field>
 
-    <button mat-button (click)="removeAllSelection()">Remove all</button>
+    <button mat-button (click)="resetSelection()">Reset</button>
 
     <div *ngIf="!hasLabels(input.value)" class="no-labels">No Labels Found!</div>
 

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -13,7 +13,7 @@
       <input #input matInput placeholder="Find labels" />
     </mat-form-field>
 
-    <button mat-button (click)="resetSelection()">Reset</button>
+    <button mat-button (click)="resetSelection()" [disabled]="isDefault">Reset</button>
 
     <div *ngIf="!hasLabels(input.value)" class="no-labels">No Labels Found!</div>
 

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -117,13 +117,15 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   updateSelection(): void {
     this.filtersService.updateFilters({
       labels: Array.from(this.selectedLabelNames),
-      deselectedLabels: this.deselectedLabelNames
+      deselectedLabels: this.deselectedLabelNames,
+      hiddenLabels: this.hiddenLabelNames
     });
   }
 
-  removeAllSelection(): void {
+  resetSelection(): void {
     this.selectedLabelNames = new Set<string>();
     this.deselectedLabelNames = new Set<string>();
+    this.hiddenLabelNames = new Set<string>();
     this.updateSelection();
   }
 }

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -44,6 +44,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
         this.hiddenLabelNames = this.filtersService.filter$.value.hiddenLabels;
         this.loaded = true;
 
+        // set the default based on the initial round of filters
         this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
       });
     });
@@ -59,8 +60,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     this.hiddenLabelNames.add(label);
-    this.isDefault = false;
-    this.filtersService.updateFilters({ hiddenLabels: this.hiddenLabelNames });
+    this.updateSelection();
   }
 
   /** Show labels that were hidden */
@@ -70,7 +70,6 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     }
     this.hiddenLabelNames.delete(label);
     this.updateSelection();
-    this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
   }
 
   /**
@@ -87,7 +86,6 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     } else {
       this.selectedLabelNames.add(label.name);
     }
-    this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
     this.updateSelection();
   }
 
@@ -127,6 +125,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       deselectedLabels: this.deselectedLabelNames,
       hiddenLabels: this.hiddenLabelNames
     });
+
+    this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
   }
 
   resetSelection(): void {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -22,6 +22,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   hiddenLabelNames: Set<string> = new Set();
   loaded = false;
 
+  isDefault = true;
+
   labelSubscription: Subscription;
 
   constructor(private labelService: LabelService, private logger: LoggingService, private filtersService: FiltersService) {}
@@ -41,6 +43,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
         this.deselectedLabelNames = this.filtersService.filter$.value.deselectedLabels;
         this.hiddenLabelNames = this.filtersService.filter$.value.hiddenLabels;
         this.loaded = true;
+
+        this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
       });
     });
   }
@@ -55,6 +59,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     this.hiddenLabelNames.add(label);
+    this.isDefault = false;
     this.filtersService.updateFilters({ hiddenLabels: this.hiddenLabelNames });
   }
 
@@ -64,7 +69,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
       return;
     }
     this.hiddenLabelNames.delete(label);
-    this.filtersService.updateFilters({ hiddenLabels: this.hiddenLabelNames });
+    this.updateSelection();
+    this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
   }
 
   /**
@@ -81,6 +87,7 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     } else {
       this.selectedLabelNames.add(label.name);
     }
+    this.isDefault = this.selectedLabelNames.size === 0 && this.deselectedLabelNames.size === 0 && this.hiddenLabelNames.size === 0;
     this.updateSelection();
   }
 
@@ -126,6 +133,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
     this.selectedLabelNames = new Set<string>();
     this.deselectedLabelNames = new Set<string>();
     this.hiddenLabelNames = new Set<string>();
+
+    this.isDefault = true;
     this.updateSelection();
   }
 }

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -117,21 +117,28 @@ describe('LabelFilterBarComponent', () => {
   });
 
   describe('updateSelection', () => {
-    it('should update filters service with selected labels', () => {
+    it('should update filters service with selected and hidden labels', () => {
       const selectedLabels = [LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW];
+      const hiddenLabels = [LABEL_NAME_SEVERITY_HIGH];
       component.selectedLabelNames = new Set<string>(selectedLabels);
+      component.hiddenLabelNames = new Set<string>(hiddenLabels);
 
       component.updateSelection();
 
-      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ labels: selectedLabels, deselectedLabels: new Set<string>() });
+      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({
+        labels: selectedLabels,
+        deselectedLabels: new Set<string>(),
+        hiddenLabels: new Set<string>(hiddenLabels)
+      });
     });
   });
 
-  describe('removeAllSelection', () => {
+  describe('resetAll', () => {
     it('should deselect all labels and update the filter', () => {
-      component.removeAllSelection();
+      component.resetSelection();
       expect(component.selectedLabelNames).toEqual(new Set<string>());
       expect(component.deselectedLabelNames).toEqual(new Set<string>());
+      expect(component.hiddenLabelNames).toEqual(new Set<string>());
     });
   });
 });

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -68,7 +68,11 @@ describe('LabelFilterBarComponent', () => {
       component.hide(label);
 
       expect(component.hiddenLabelNames).toContain(label);
-      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ hiddenLabels: component.hiddenLabelNames });
+      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({
+        hiddenLabels: component.hiddenLabelNames,
+        labels: [],
+        deselectedLabels: new Set<string>([])
+      });
     });
   });
 
@@ -81,7 +85,11 @@ describe('LabelFilterBarComponent', () => {
       component.show(label);
 
       expect(component.hiddenLabelNames).not.toContain(label);
-      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({ hiddenLabels: component.hiddenLabelNames });
+      expect(filtersServiceSpy.updateFilters).toHaveBeenCalledWith({
+        hiddenLabels: new Set<string>([]),
+        labels: [],
+        deselectedLabels: new Set<string>([])
+      });
     });
   });
 
@@ -139,6 +147,8 @@ describe('LabelFilterBarComponent', () => {
       expect(component.selectedLabelNames).toEqual(new Set<string>());
       expect(component.deselectedLabelNames).toEqual(new Set<string>());
       expect(component.hiddenLabelNames).toEqual(new Set<string>());
+
+      expect(component.isDefault).toBeTrue();
     });
   });
 });


### PR DESCRIPTION
### Summary:

Fixes #398 

#### Type of change:
- ✨ New Enhancement
- 🐛 Bug Fix
- 🧪 Tests Update

### Changes Made:
Previously, the "remove all" button was ambigious in its function. Let's move to refactor it such that it resets all modifications made to the filters instead.

### Screenshots:


https://github.com/user-attachments/assets/7be7ede1-fcf8-425c-9017-e1217818c357



### Proposed Commit Message:

```
Fix remove all button

The current "remove all" button might
lead to confusion in its function, as it doesn't
"remove" all changes made to the label selection.

Let's rename the button to "reset" to make it more
clear, and fix its function such that it resets all 
changes instead.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
