### PR TITLE
Remove gap between bottom of window and horizontal sidebar using flexbox

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,4 +1,5 @@
 .container {
   padding: 8px 16px;
   min-height: 87.9vh;
+  flex-grow: 1;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<app-layout-header></app-layout-header>
+<app-layout-header style="flex: 0 0 auto"></app-layout-header>
 
 <div class="container">
   <router-outlet></router-outlet>

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -1,6 +1,6 @@
 .card-column {
   margin: 8px;
-  height: 100vh;
+  height: calc(100vh - 192px);
   display: flex;
   flex-direction: column;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -1,6 +1,6 @@
 .card-column {
   margin: 8px;
-  height: 77vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -1,6 +1,6 @@
 .card-column {
   margin: 8px;
-  height: calc(100vh - 192px);
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -1,3 +1,9 @@
+.issues-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .issue-table {
   width: 25%;
   min-width: 200px;
@@ -35,6 +41,7 @@
   display: flex;
   overflow-x: auto;
   /* white-space: nowrap; */
+  flex-grow: 1;
 }
 
 .loading-spinner {

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -1,10 +1,10 @@
-<div>
+<div class="issues-viewer">
   <div class="loading-spinner" *ngIf="(this.viewService.isChangingRepo | async) || this.groupService.groups.length === 0; else elseBlock">
     <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"> </mat-progress-spinner>
   </div>
 
   <ng-template #elseBlock>
-    <app-filter-bar [views$]="views"></app-filter-bar>
+    <app-filter-bar [views$]="views" style="flex: 0 0 auto"></app-filter-bar>
 
     <div class="wrapper">
       <app-card-view

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,6 +17,12 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
+app-root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
 /* Timeline comment style */
 .timeline-header {
   background-color: #f1f8ff;


### PR DESCRIPTION
### Summary:

Fixes #416 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Initially, each column was set to a height of 77vh in card-view component, which resulted in a weird gap between the bottom of the window and the horizontal sidebar on screens that have enough vertical height. 
- Setting the height to (100vh - filter bar height - header height) may not be a feasible solution as the heights will be hardcoded and need to be changed when the height of the filter bar / header changes.
- Thus I modified `app-root` to be a flexbox, which allows the content to take up the remaining vertical space of the viewport.  

### Screenshots:

Before:
![image](https://github.com/user-attachments/assets/ea81deac-0bb9-45aa-b56c-4305094ed26f)

After:
![image](https://github.com/user-attachments/assets/5785c102-0f40-48fa-b2a9-cbb8b1df474e)


### Proposed Commit Message:

```
Remove gap between bottom of window and horizontal sidebar

The height of each column in `card-view` component is set to 77vh,
which results in a gap between the bottom of the window and the
horizontal sidebar. 

The content should fill up the remaining height of the window instead
of leaving a gap.

Let's use a flexbox to allow the content to dynamically change its
height to fill up the remaining space instead of having a fixed height.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
