### PR TITLE
Add side border to draft PR cards

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -38,7 +38,7 @@ export class IssuePrCardComponent {
   getIssueOpenOrCloseColorCSSClass() {
     if (this.issue.state === 'OPEN') {
       if (this.issue.isDraft) {
-        return 'grey';
+        return 'border-gray';
       } else {
         return 'border-green';
       }


### PR DESCRIPTION
### Summary:

Fixes #419

#### Type of change:
- 🐛 Bug Fix

### Changes Made:

- Added a side border color to draft PR cards

### Screenshots:

Before:
<img width="265" alt="Screenshot 2025-03-05 at 1 08 49 AM" src="https://github.com/user-attachments/assets/ae195539-7997-4eb4-a61c-18b3ce5e437d" />


After:
<img width="265" alt="Screenshot 2025-03-05 at 1 08 00 AM" src="https://github.com/user-attachments/assets/645ea3a8-ad86-4839-9f7c-b68521d50443" />


Additional info:
I used the same border color as `Not Planned Issue`, I think this is ok, but if we think we should use a different shade of grey, I can make the changes as well (mainly because I am not sure what shade of grey should be used)

### Proposed Commit Message:

```
Add side border to draft PR cards
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to an issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
