### PR TITLE
Update version deployment workflow to allow manual running

### DIFF
--- a/.github/workflows/deployment-actions.yml
+++ b/.github/workflows/deployment-actions.yml
@@ -6,8 +6,8 @@
 name: Version Deployment
 
 on:
-  push:
-    branches: deploy
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   deploy_web:


### PR DESCRIPTION
### Summary:

Fixes #431 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Change the version deployment workflow file to be on workflow_dispatch over on push to deploy branch

### Proposed Commit Message:

```
Update version deployment workflow

Version deployment is setup to run on push to deploy branch.

This is not consistent with CATcher's workflow, which is to manually
run the deployment from the actions tab on Github.

Let's update this to follow CATcher's workflow, changing it to be
manually run from the actions tab on Github.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
