### PR TITLE
Add drag and drop functionality to reassign assignees and milestones

### DIFF
--- a/graphql/fragments/issue-label.fragment.graphql
+++ b/graphql/fragments/issue-label.fragment.graphql
@@ -1,4 +1,5 @@
 fragment issueLabel on Label {
   color
   name
+  id
 }

--- a/graphql/fragments/issue-milestone.fragment.graphql
+++ b/graphql/fragments/issue-milestone.fragment.graphql
@@ -2,4 +2,5 @@ fragment issueMilestone on Milestone {
   number
   title
   state
+  id
 }

--- a/graphql/mutations/update-issue.graphql
+++ b/graphql/mutations/update-issue.graphql
@@ -1,0 +1,29 @@
+mutation UpdateIssueAssignees($input: UpdateIssueInput!, $commentCursor: String) {
+  updateIssue(input: $input) {
+    issue {
+      ...issue
+      labels(first: 100) {
+        edges {
+          node {
+            ...issueLabel
+          }
+        }
+      }
+      assignees(first: 100) {
+        edges {
+          node {
+            ...issueAssignee
+          }
+        }
+      }
+      comments(first: 100, after: $commentCursor) {
+        edges {
+          cursor
+          node {
+            ...issueComment
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WATcher",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "main.js",
   "scripts": {
     "ng": "ng",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -92,11 +92,9 @@ export class AppModule {
       operation.setContext({ start: performance.now() });
       this.logger.info('AppModule: GraphQL request', operation.getContext());
       return forward(operation).map((result) => {
+        // Log the response time
         const time = performance.now() - operation.getContext().start;
         this.logger.info('AppModule: GraphQL response', operation.getContext(), `in ${Math.round(time)}ms`);
-        const repo = operation.getContext().response.body.data.repository;
-        const item = Object.keys(repo)[0];
-        this.logger.debug('AppModule: GraphQL response body', item, repo[item].edges.length, repo[item].edges);
         return result;
       });
     });
@@ -114,6 +112,7 @@ export class AppModule {
         possibleTypes[type.name] = type.possibleTypes.map((possibleType: any) => possibleType.name);
       }
     });
+
     const cache = new InMemoryCache({ possibleTypes });
     this.apollo.create({
       link: link,

--- a/src/app/core/models/github/github-issue.model.ts
+++ b/src/app/core/models/github/github-issue.model.ts
@@ -25,6 +25,7 @@ export class GithubIssue {
     number: string; // id for milestone
     title: string;
     state: string;
+    id: string;
   };
   comments?: Array<GithubComment>;
   issueOrPr?: string;

--- a/src/app/core/models/github/github-label.model.ts
+++ b/src/app/core/models/github/github-label.model.ts
@@ -16,7 +16,7 @@ export class GithubLabel {
   };
 
   color: string;
-  // id: number;
+  id: string;
   name: string;
   category: string;
   label: string;

--- a/src/app/core/models/milestone.model.ts
+++ b/src/app/core/models/milestone.model.ts
@@ -4,18 +4,20 @@ import { Group } from './github/group.interface';
  * Represents a milestone and its attributes fetched from Github.
  */
 export class Milestone implements Group {
-  static IssueWithoutMilestone: Milestone = new Milestone({ title: 'Issue without a milestone', state: null });
-  static PRWithoutMilestone: Milestone = new Milestone({ title: 'PR without a milestone', state: null });
+  static IssueWithoutMilestone: Milestone = new Milestone({ title: 'Issue without a milestone', state: null, id: null });
+  static PRWithoutMilestone: Milestone = new Milestone({ title: 'PR without a milestone', state: null, id: null });
   title: string;
   state: string;
   deadline?: Date;
   number?: number;
+  id: string;
 
-  constructor(milestone: { title: string; state: string; due_on?: string; number?: string }) {
+  constructor(milestone: { title: string; state: string; due_on?: string; number?: string; id?: string; node_id?: string }) {
     this.title = milestone.title;
     this.state = milestone.state;
     this.deadline = milestone.due_on ? new Date(milestone.due_on) : undefined;
     this.number = milestone.number ? +milestone.number : undefined;
+    this.id = milestone.node_id ? milestone.node_id : milestone.id;
   }
 
   public equals(other: any) {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -209,7 +209,7 @@ export class AuthService {
   startOAuthProcess(hasPrivateConsent: boolean) {
     this.logger.info('AuthService: Starting authentication');
     // Available OAuth scopes https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
-    let permissionLevel = 'public-repo';
+    let permissionLevel = 'public_repo';
 
     if (hasPrivateConsent) {
       // grants WATcher access to private repos if user allows

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -12,7 +12,9 @@ import {
   FetchIssues,
   FetchIssuesQuery,
   FetchPullRequests,
-  FetchPullRequestsQuery
+  FetchPullRequestsQuery,
+  UpdateIssueAssignees,
+  UpdateIssueAssigneesMutation
 } from '../../../../graphql/graphql-types';
 import { AppConfig } from '../../../environments/environment';
 import { getNumberOfPages } from '../../shared/lib/github-paginator-parser';
@@ -30,6 +32,8 @@ import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { ErrorMessageService } from './error-message.service';
 import { LoggingService } from './logging.service';
+import { Issue } from '../models/issue.model';
+import { Milestone } from '../models/milestone.model';
 
 const { Octokit } = require('@octokit/rest');
 
@@ -226,7 +230,7 @@ export class GithubService {
    * @param id - The issue id.
    * @returns Observable<GithubGraphqlIssue> that represents the response object.
    */
-  fetchIssueGraphql(id: number): Observable<GithubGraphqlIssue> {
+  fetchIssueGraphql(id: number): Observable<GithubIssue> {
     if (this.issueQueryRefs.get(id) === undefined) {
       const newQueryRef = this.apollo.watchQuery<FetchIssueQuery>({
         query: FetchIssue,
@@ -589,5 +593,38 @@ export class GithubService {
     queryWith(null);
 
     return behaviorSubject.asObservable();
+  }
+
+  /**
+   * Updates the assignees of an issue using GraphQL mutation.
+   * @param issue - The issue object to update
+   * @param assignees - Array of assignees to set
+   * @returns Observable<GithubGraphqlIssue> that represents the updated issue
+   */
+  updateIssueAssignees(issue: Issue, assignees: GithubUser[], milestone: Milestone): Observable<GithubIssue> {
+    // Log the input values for debugging
+    return this.apollo
+      .mutate<UpdateIssueAssigneesMutation>({
+        mutation: UpdateIssueAssignees,
+        variables: {
+          input: {
+            id: issue.globalId,
+            assigneeIds: assignees.map((assignee) => assignee.node_id),
+            projectIds: [],
+            labelIds: issue.githubLabels?.map((label) => label.id) || [],
+            milestoneId: milestone.id
+          }
+        }
+      })
+      .pipe(
+        map((result: ApolloQueryResult<UpdateIssueAssigneesMutation>) => {
+          console.log('GITHUB ISSUE', result.data.updateIssue.issue);
+          return new GithubGraphqlIssueOrPr(result.data.updateIssue.issue);
+        }),
+        catchError((error) => {
+          this.errorHandlingService.handleError(error);
+          return throwError(() => error);
+        })
+      );
   }
 }

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -28,12 +28,12 @@ import RestGithubIssueFilter from '../models/github/github-issue-filter.model';
 import { GithubIssue } from '../models/github/github-issue.model';
 import { GithubResponse } from '../models/github/github-response.model';
 import { GithubRelease } from '../models/github/github.release';
+import { Issue } from '../models/issue.model';
+import { Milestone } from '../models/milestone.model';
 import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { ErrorMessageService } from './error-message.service';
 import { LoggingService } from './logging.service';
-import { Issue } from '../models/issue.model';
-import { Milestone } from '../models/milestone.model';
 
 const { Octokit } = require('@octokit/rest');
 

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, of, Subscription, throwError, timer } from 'rxjs';
 import { catchError, exhaustMap, finalize, map } from 'rxjs/operators';
+import { GithubUser } from '../models/github-user.model';
 import RestGithubIssueFilter from '../models/github/github-issue-filter.model';
 import { GithubIssue } from '../models/github/github-issue.model';
 import { Issue, Issues, IssuesFilter } from '../models/issue.model';
+import { Milestone } from '../models/milestone.model';
 import { View } from '../models/view.model';
 import { GithubService } from './github.service';
 import { UserService } from './user.service';
 import { ViewService } from './view.service';
-import { Milestone } from '../models/milestone.model';
-import { GithubUser } from '../models/github-user.model';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -74,9 +74,10 @@ export class IssueService {
   }
 
   updateIssue(issue: Issue, assignees: GithubUser[], milestone: Milestone): Observable<Issue> {
+    this.deleteIssuesFromLocalStore([issue.id]);
+
     return this.githubService.updateIssueAssignees(issue, assignees, milestone).pipe(
       map((response: GithubIssue) => {
-        console.log('ISSUE', response);
         this.createAndSaveIssueModels([response]);
         return this.issues[issue.id];
       }),

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -8,6 +8,8 @@ import { View } from '../models/view.model';
 import { GithubService } from './github.service';
 import { UserService } from './user.service';
 import { ViewService } from './view.service';
+import { Milestone } from '../models/milestone.model';
+import { GithubUser } from '../models/github-user.model';
 
 @Injectable({
   providedIn: 'root'
@@ -69,6 +71,19 @@ export class IssueService {
     } else {
       return of(this.issues[id]);
     }
+  }
+
+  updateIssue(issue: Issue, assignees: GithubUser[], milestone: Milestone): Observable<Issue> {
+    return this.githubService.updateIssueAssignees(issue, assignees, milestone).pipe(
+      map((response: GithubIssue) => {
+        console.log('ISSUE', response);
+        this.createAndSaveIssueModels([response]);
+        return this.issues[issue.id];
+      }),
+      catchError((err) => {
+        return of(this.issues[issue.id]);
+      })
+    );
   }
 
   getLatestIssue(id: number): Observable<Issue> {

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -143,3 +143,43 @@ div.column-header .mat-card-header {
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-range-actions {
   display: none !important;
 }
+
+.cdk-drop-list-dragging {
+  opacity: 0.5;
+}
+
+.cdk-drag-placeholder {
+  display: none;
+  opacity: 0;
+}
+
+.overlay {
+  display: none;
+}
+
+.plus-sign {
+  display: none;
+}
+
+.cdk-drop-list-dragging > .overlay {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 2px dashed black;
+  border-radius: 5px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  z-index: 1000;
+}
+
+.cdk-drop-list-dragging > .plus-sign {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -144,23 +144,26 @@ div.column-header .mat-card-header {
   display: none !important;
 }
 
+/* This is when the card is being dragged over this list */
 .cdk-drop-list-dragging {
   opacity: 0.5;
 }
 
+/* This is the placeholder for the card that appears in the list it is being dragged over */
 .cdk-drag-placeholder {
   display: none;
   opacity: 0;
 }
 
+/* This is the issue card that follows the cursor */
+.cdk-drag-preview {
+  opacity: 0.5;
+}
 .overlay {
   display: none;
 }
 
-.plus-sign {
-  display: none;
-}
-
+/* This is when the card is being dragged over this list */
 .cdk-drop-list-dragging > .overlay {
   display: block;
   position: absolute;
@@ -174,12 +177,4 @@ div.column-header .mat-card-header {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   z-index: 1000;
-}
-
-.cdk-drop-list-dragging > .plus-sign {
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
 }

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -5,7 +5,6 @@
   ></ng-container>
   <div class="scrollable-container-wrapper scroll-shadow" cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
     <div class="overlay"></div>
-    <div class="plus-sign">+</div>
 
     <div class="scrollable-container">
       <div class="issue-pr-cards" *ngFor="let issue of this.issues$ | async; index as i">

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -1,14 +1,23 @@
-<div class="card-column" cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+<div class="card-column">
   <ng-container
     [ngTemplateOutlet]="getHeaderTemplate() || defaultHeader"
     [ngTemplateOutletContext]="{ $implicit: this.group }"
   ></ng-container>
-  <div class="scrollable-container-wrapper scroll-shadow">
+  <div class="scrollable-container-wrapper scroll-shadow" cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+    <div class="overlay"></div>
+    <div class="plus-sign">+</div>
+
     <div class="scrollable-container">
       <div class="issue-pr-cards" *ngFor="let issue of this.issues$ | async; index as i">
-        <app-issue-pr-card [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService"></app-issue-pr-card>
+        <app-issue-pr-card
+          [issue]="issue"
+          [filter]="issues.filter"
+          [milestoneService]="milestoneService"
+          cdkDrag
+          [cdkDragData]="issue"
+        ></app-issue-pr-card>
       </div>
-      <mat-card class="loading-spinner" *ngIf="this.issues.isLoading$ | async">
+      <mat-card class="loading-spinner" *ngIf="isLoading">
         <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
       </mat-card>
     </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -1,4 +1,4 @@
-<div class="card-column">
+<div class="card-column" cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
   <ng-container
     [ngTemplateOutlet]="getHeaderTemplate() || defaultHeader"
     [ngTemplateOutletContext]="{ $implicit: this.group }"

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -1,3 +1,4 @@
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import {
   AfterViewInit,
   Component,
@@ -12,8 +13,10 @@ import {
 } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { Observable, Subscription } from 'rxjs';
+import { GithubUser } from '../../core/models/github-user.model';
 import { Group } from '../../core/models/github/group.interface';
 import { Issue } from '../../core/models/issue.model';
+import { Milestone } from '../../core/models/milestone.model';
 import { AssigneeService } from '../../core/services/assignee.service';
 import { FiltersService } from '../../core/services/filters.service';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
@@ -22,9 +25,6 @@ import { LoggingService } from '../../core/services/logging.service';
 import { MilestoneService } from '../../core/services/milestone.service';
 import { FilterableComponent, FilterableSource } from '../../shared/issue-tables/filterableTypes';
 import { IssuesDataTable } from '../../shared/issue-tables/IssuesDataTable';
-import { CdkDragDrop } from '@angular/cdk/drag-drop';
-import { GithubUser } from '../../core/models/github-user.model';
-import { Milestone } from '../../core/models/milestone.model';
 
 @Component({
   selector: 'app-card-view',

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -22,6 +22,9 @@ import { LoggingService } from '../../core/services/logging.service';
 import { MilestoneService } from '../../core/services/milestone.service';
 import { FilterableComponent, FilterableSource } from '../../shared/issue-tables/filterableTypes';
 import { IssuesDataTable } from '../../shared/issue-tables/IssuesDataTable';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { GithubUser } from '../../core/models/github-user.model';
+import { Milestone } from '../../core/models/milestone.model';
 
 @Component({
   selector: 'app-card-view',
@@ -136,5 +139,13 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
 
   retrieveFilterable(): FilterableSource {
     return this.issues;
+  }
+
+  drop(event: CdkDragDrop<Group>) {
+    if (event.container.data instanceof GithubUser) {
+      const assigneeToRemove = event.previousContainer.data;
+      const assigneeToAdd = event.container.data;
+    } else if (event.container.data instanceof Milestone) {
+    }
   }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -99,11 +99,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
       this.issuesLengthSubscription = this.issues$.subscribe(() => {
         this.issueLength = this.issues.count;
         this.issueLengthChange.emit(this.issueLength);
-      });
-
-      // Emit event when loading state changes
-      this.issuesLoadingStateSubscription = this.issues.isLoading.subscribe((isLoadingUpdate) => {
-        this.isLoading = isLoadingUpdate;
+        // Set loading to false when issues change
+        this.isLoading = false;
       });
     });
   }
@@ -147,7 +144,6 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
       return;
     }
     const issue: Issue = event.item.data;
-
     // If the item is being dropped in the same container, do nothing
     if (event.previousContainer === event.container) {
       return;

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
@@ -80,3 +80,42 @@
 .scrollable-container::after {
   position: sticky;
 }
+
+.cdk-drop-list-dragging {
+  opacity: 0.5;
+}
+
+.overlay {
+  display: none;
+}
+
+.plus-sign {
+  display: none;
+}
+
+.cdk-drop-list-dragging > .overlay {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 2px dashed black;
+  border-radius: 5px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  z-index: 1000;
+}
+
+.cdk-drop-list-dragging > .plus-sign {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.2;
+}

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
@@ -81,6 +81,7 @@
   position: sticky;
 }
 
+/* This is when the card is being dragged over this list */
 .cdk-drop-list-dragging {
   opacity: 0.5;
 }
@@ -89,10 +90,7 @@
   display: none;
 }
 
-.plus-sign {
-  display: none;
-}
-
+/* This is when the card is being dragged over this list */
 .cdk-drop-list-dragging > .overlay {
   display: block;
   position: absolute;
@@ -106,16 +104,4 @@
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   z-index: 1000;
-}
-
-.cdk-drop-list-dragging > .plus-sign {
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.cdk-drag-placeholder {
-  opacity: 0.2;
 }

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -22,7 +22,9 @@
 </ng-template>
 
 <ng-template #assigneeCard let-assignee>
-  <mat-card>
+  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+    <div class="overlay"></div>
+    <div class="plus-sign">+</div>
     <mar-card-header class="mat-card-header">
       <div
         mat-card-avatar
@@ -37,7 +39,9 @@
 </ng-template>
 
 <ng-template #milestoneCard let-milestone>
-  <mat-card>
+  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+    <div class="overlay"></div>
+    <div class="plus-sign">+</div>
     <mar-card-header class="mat-card-header">
       <mat-card-title>{{ milestone.title }}</mat-card-title>
     </mar-card-header>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -22,9 +22,8 @@
 </ng-template>
 
 <ng-template #assigneeCard let-assignee>
-  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="assignee">
     <div class="overlay"></div>
-    <div class="plus-sign">+</div>
     <mar-card-header class="mat-card-header">
       <div
         mat-card-avatar
@@ -39,9 +38,8 @@
 </ng-template>
 
 <ng-template #milestoneCard let-milestone>
-  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="group">
+  <mat-card cdkDropList (cdkDropListDropped)="drop($event)" [cdkDropListData]="milestone">
     <div class="overlay"></div>
-    <div class="plus-sign">+</div>
     <mar-card-header class="mat-card-header">
       <mat-card-title>{{ milestone.title }}</mat-card-title>
     </mar-card-header>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -1,7 +1,13 @@
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { AfterViewInit, Component, Input, TemplateRef, ViewChild } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { GithubUser } from '../../core/models/github-user.model';
 import { Group } from '../../core/models/github/group.interface';
+import { Issue } from '../../core/models/issue.model';
+import { Milestone } from '../../core/models/milestone.model';
+import { AssigneeService } from '../../core/services/assignee.service';
 import { GroupBy, GroupingContextService } from '../../core/services/grouping/grouping-context.service';
+import { IssueService } from '../../core/services/issue.service';
 
 @Component({
   selector: 'app-hidden-groups',
@@ -17,7 +23,11 @@ export class HiddenGroupsComponent implements AfterViewInit {
 
   private currentCardTemplate$ = new BehaviorSubject<TemplateRef<any>>(null);
 
-  constructor(public groupingContextService: GroupingContextService) {}
+  constructor(
+    public groupingContextService: GroupingContextService,
+    public assigneeService: AssigneeService,
+    private issueService: IssueService
+  ) {}
 
   ngAfterViewInit() {
     setTimeout(() => {
@@ -33,6 +43,43 @@ export class HiddenGroupsComponent implements AfterViewInit {
         return this.milestoneCardTemplate;
       default:
         return this.defaultCardTemplate;
+    }
+  }
+
+  drop(event: CdkDragDrop<Group>) {
+    if (!(event.item.data instanceof Issue)) {
+      return;
+    }
+    const issue: Issue = event.item.data;
+
+    // If the item is being dropped in the same container, do nothing
+    if (event.previousContainer === event.container) {
+      return;
+    }
+
+    if (event.container.data instanceof GithubUser && event.previousContainer.data instanceof GithubUser) {
+      const assigneeToRemove = event.previousContainer.data;
+      const assigneeToAdd = event.container.data;
+      const assignees = this.assigneeService.assignees.filter((assignee) => issue.assignees.includes(assignee.login));
+
+      if (assigneeToRemove !== GithubUser.NO_ASSIGNEE) {
+        const index = assignees.findIndex((assignee) => assignee.login === assigneeToRemove.login);
+        if (index !== -1) {
+          assignees.splice(index, 1);
+        }
+      }
+      if (assigneeToAdd !== GithubUser.NO_ASSIGNEE) {
+        assignees.push(assigneeToAdd);
+      }
+
+      this.issueService.updateIssue(issue, assignees, issue.milestone).subscribe();
+    } else if (event.container.data instanceof Milestone) {
+      // assigneeIds is a mandatory field for the updateIssue mutation
+      const assignees = this.assigneeService.assignees.filter((assignee) => issue.assignees.includes(assignee.login));
+
+      const milestoneToAdd = event.container.data;
+
+      this.issueService.updateIssue(issue, assignees, milestoneToAdd).subscribe();
     }
   }
 }

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -6,7 +6,7 @@
   <ng-template #elseBlock>
     <app-filter-bar [views$]="views"></app-filter-bar>
 
-    <div class="wrapper">
+    <div class="wrapper" cdkDropListGroup>
       <app-card-view
         *ngFor="let group of this.groupService.groups"
         class="issue-table"

--- a/src/app/issues-viewer/issues-viewer.module.ts
+++ b/src/app/issues-viewer/issues-viewer.module.ts
@@ -6,9 +6,10 @@ import { CardViewComponent } from './card-view/card-view.component';
 import { HiddenGroupsComponent } from './hidden-groups/hidden-groups.component';
 import { IssuesViewerRoutingModule } from './issues-viewer-routing.module';
 import { IssuesViewerComponent } from './issues-viewer.component';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
-  imports: [FilterBarModule, IssuesViewerRoutingModule, IssuesPrCardModule, SharedModule],
+  imports: [DragDropModule, FilterBarModule, IssuesViewerRoutingModule, IssuesPrCardModule, SharedModule],
   declarations: [IssuesViewerComponent, CardViewComponent, HiddenGroupsComponent],
   exports: [IssuesViewerComponent, CardViewComponent]
 })

--- a/src/app/issues-viewer/issues-viewer.module.ts
+++ b/src/app/issues-viewer/issues-viewer.module.ts
@@ -1,3 +1,4 @@
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { NgModule } from '@angular/core';
 import { FilterBarModule } from '../shared/filter-bar/filter-bar.module';
 import { IssuesPrCardModule } from '../shared/issue-pr-card/issue-pr-card.module';
@@ -6,7 +7,6 @@ import { CardViewComponent } from './card-view/card-view.component';
 import { HiddenGroupsComponent } from './hidden-groups/hidden-groups.component';
 import { IssuesViewerRoutingModule } from './issues-viewer-routing.module';
 import { IssuesViewerComponent } from './issues-viewer.component';
-import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
   imports: [DragDropModule, FilterBarModule, IssuesViewerRoutingModule, IssuesPrCardModule, SharedModule],

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.css
@@ -1,6 +1,6 @@
 .card {
   margin: 8px 0px 8px 0px;
-  background-color: transparent;
+  background-color: white;
 }
 
 .mat-card {

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()" cdkDrag [cdkDragData]="issue">
+<mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
   <a class="no-underline link-grey-dark">
     <span [matTooltip]="this.issue.updated_at">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
+<mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()" cdkDrag [cdkDragData]="issue">
   <a class="no-underline link-grey-dark">
     <span [matTooltip]="this.issue.updated_at">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>

--- a/src/app/shared/issue-pr-card/issue-pr-card.module.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.module.ts
@@ -1,10 +1,10 @@
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared.module';
 import { IssuePrCardHeaderComponent } from './issue-pr-card-header/issue-pr-card-header.component';
 import { IssuePrCardLabelsComponent } from './issue-pr-card-labels/issue-pr-card-labels.component';
 import { IssuePrCardMilestoneComponent } from './issue-pr-card-milestone/issue-pr-card-milestone.component';
 import { IssuePrCardComponent } from './issue-pr-card.component';
-import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
   imports: [SharedModule, DragDropModule],

--- a/src/app/shared/issue-pr-card/issue-pr-card.module.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.module.ts
@@ -4,9 +4,10 @@ import { IssuePrCardHeaderComponent } from './issue-pr-card-header/issue-pr-card
 import { IssuePrCardLabelsComponent } from './issue-pr-card-labels/issue-pr-card-labels.component';
 import { IssuePrCardMilestoneComponent } from './issue-pr-card-milestone/issue-pr-card-milestone.component';
 import { IssuePrCardComponent } from './issue-pr-card.component';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
-  imports: [SharedModule],
+  imports: [SharedModule, DragDropModule],
   declarations: [IssuePrCardComponent, IssuePrCardHeaderComponent, IssuePrCardMilestoneComponent, IssuePrCardLabelsComponent],
   exports: [IssuePrCardComponent]
 })

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -21,7 +21,9 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
 
-  public isLoading$ = this.issueService.isLoading.asObservable();
+  private isLoading$ = new BehaviorSubject<boolean>(false);
+  private isLoadingSubscription: Subscription;
+  public isLoading = this.isLoading$.asObservable();
 
   constructor(
     private issueService: IssueService,
@@ -38,6 +40,10 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   }
 
   connect(): Observable<Issue[]> {
+    this.isLoadingSubscription = this.issueService.isLoading.subscribe((isLoading) => {
+      this.isLoading$.next(isLoading);
+    });
+
     return this.issuesSubject.asObservable();
   }
 
@@ -47,6 +53,10 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
     if (this.issueSubscription) {
       this.issueSubscription.unsubscribe();
     }
+    if (this.isLoadingSubscription) {
+      this.isLoadingSubscription.unsubscribe();
+    }
+
     this.issueService.stopPollIssues();
   }
 
@@ -86,6 +96,7 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
       )
       .subscribe((issues) => {
         this.issuesSubject.next(issues);
+        this.isLoading$.next(false);
       });
   }
 


### PR DESCRIPTION
### Summary:

Added functionality to drag and drop to reassign assignees and milestones 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Added a new GraphQL mutation
- Adjusted some GraphQL fragments to include ID
- Fixed OAuth not granting public_repo scope
- Used CdkDragDrop to implement drag and drop functionality
- Updated card-view-component.ts isLoading property to change on IssuesDataTable changed issues instead of when issueServices changes, to account for changes on a smaller scale

### Proposed commit message

```
Add feature to reassign issues and change milestone

There is no way to reassign issues or change milestones in WATcher.

Reassigning issues and changing milestones is done regularly by small
teams working on their projects, especially during team meetings.

Let's add a feature to allow dragging and dropping issues to reassign
the assignees and change the milestone.

Teams will then have a convenient way to reassign and change
milestones.
```
### Screenshots:

https://github.com/user-attachments/assets/7ca93fe1-4458-4833-a017-7ac8d53957d3

Note: A bug is displayed in the video where after moving an issue, the polling occurs, causing the issue to reappear briefly. No idea how to fix that.