### PR TITLE
Remove back and home button

### DIFF
--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -1,21 +1,7 @@
 <mat-toolbar color="primary" style="position: sticky; position: -webkit-sticky; top: 0; z-index: 1000">
   <div class="toolbar-wrapper">
     <div class="left">
-      <button
-        *ngIf="isBackButtonShown()"
-        mat-icon-button
-        class="mat-toolbar mat-primary back-button"
-        style="transform: scale(0.9)"
-        (click)="goBack()"
-      >
-        <mat-icon>arrow_back_ios</mat-icon>
-      </button>
-      <a
-        class="mat-toolbar mat-primary"
-        style="text-decoration: none"
-        [routerLink]="viewService.isRepoSet() ? viewService.currentView : null"
-        >WATcher v{{ this.getVersion() }}</a
-      >
+      <div class="mat-toolbar mat-primary">WATcher v{{ this.getVersion() }}</div>
       <div *ngIf="viewService.isRepoSet()" style="margin-left: 20px">
         <button mat-button [matMenuTriggerFor]="menu">
           <span class="header-main-text">

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -154,14 +154,6 @@ export class HeaderComponent implements OnInit {
     return ViewDescription[openView];
   }
 
-  goBack() {
-    if (this.prevUrl === `/${this.viewService.currentView}/issues/new`) {
-      this.router.navigateByUrl(this.viewService.currentView);
-    } else {
-      this.location.back();
-    }
-  }
-
   viewBrowser() {
     const encoded_filter_params = this.filtersService.getEncodedFilter();
     window.open('https://github.com/'.concat(this.githubService.getRepoURL()).concat('/issues?q=').concat(encoded_filter_params));


### PR DESCRIPTION
### Summary:

Fixes #448 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Remove the back button (Currently, it just runs location.back(), which is not particularly needed functionality for WATcher)
- Remove the click function of the WATcher vX.X.X button. (This button is very buggy and causes errors. The functionality is carried over from CATcher and is not needed in WATcher)

### Proposed Commit Message:

```
Remove back and home buttons

The back button and home button have ambiguous functions, and can
occasionally cause error messages to pop up.

This confuses the user, especially when they expect the back button to
bring them back to the repository selection page.

Let's remove the back and home buttons.

The back and home buttons are relics brought over from CATcher and do
not contribute significantly to WATcher's functionality. So, they can
and should be removed.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
