### PR TITLE
Change keep filters to use slider button

### DIFF
--- a/src/app/shared/layout/header.component.css
+++ b/src/app/shared/layout/header.component.css
@@ -15,7 +15,7 @@
 }
 
 .keep-filter-slider {
-  margin-top: 5px;
+  margin-top: 15px;
 }
 
 ::ng-deep .keep-filter-slider .mat-ripple {

--- a/src/app/shared/layout/header.component.css
+++ b/src/app/shared/layout/header.component.css
@@ -1,7 +1,8 @@
 .repo-menu-footer {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   position: sticky;
   bottom: 0;
   z-index: 1;
@@ -10,10 +11,15 @@
 
 .new-repo-button {
   flex-grow: 1;
+  width: 100%;
 }
 
-.keep-filter-button {
-  margin-left: 2px;
+.keep-filter-slider {
+  margin-top: 5px;
+}
+
+::ng-deep .keep-filter-slider .mat-ripple {
+  display: none;
 }
 
 .repo-options {

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -75,15 +75,15 @@
             <mat-icon>add</mat-icon>
           </button>
 
-          <button
-            mat-icon-button
-            (click)="toggleKeepFilters($event)"
-            class="keep-filter-button"
-            matTooltip="{{ keepFilters ? 'Keep filter on' : 'Keep filter off' }}"
-            color="{{ keepFilters ? 'primary' : 'warn' }}"
+          <mat-slide-toggle
+            [(ngModel)]="keepFilters"
+            (click)="$event.stopPropagation()"
+            color="primary"
+            class="keep-filter-slider"
+            labelPosition="before"
           >
-            <mat-icon>{{ keepFilters ? 'filter_alt' : 'filter_alt_off' }}</mat-icon>
-          </button>
+            Keep current filters
+          </mat-slide-toggle>
         </div>
       </mat-menu>
     </div>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -275,11 +275,6 @@ export class HeaderComponent implements OnInit {
     this.changeRepositoryIfValid(newRepo, newRepo.toString(), this.keepFilters);
   }
 
-  toggleKeepFilters(event: MouseEvent) {
-    event.stopPropagation();
-    this.keepFilters = !this.keepFilters;
-  }
-
   openChangeRepoDialog() {
     const dialogRef = this.dialogService.openChangeRepoDialog(this.currentRepo);
 


### PR DESCRIPTION
### Summary:

Fixes #440 

#### Type of change:
- ✨ New Feature/ Enhancement

### Changes Made:

- Instead of using a single icon to indicate whether keep filters is on, changed to use a slider button

### Screenshots:

https://github.com/user-attachments/assets/9779dc47-cdb2-4246-9b21-1dd1a0cd35dc


### Proposed Commit Message:

```
Change keep filters to use slider button

Functionality of keep filters icon is not clear.

Let's change it to use a slider button with
more obvious descriptions instead.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to an issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
