### PR TITLE
Prevent label overflow in card with ellipsis and tooltip

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.css
@@ -4,6 +4,15 @@
   padding: 11px 7px;
   min-height: 16px;
   margin: 2px;
+  max-width: 100%;
+}
+
+.label-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
 }
 
 :host ::ng-deep .mat-chip-list-wrapper .mat-standard-chip,

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
@@ -1,7 +1,7 @@
 <mat-chip-list aria-label="Labels">
   <ng-container *ngFor="let label of labels">
     <mat-chip *ngIf="!labelSet?.has(label.name)" [ngStyle]="labelService.setLabelStyle(label.color)" selected>
-      {{ label.name }}
+      <span class="label-text">{{ label.name }}</span>
     </mat-chip>
   </ng-container>
 </mat-chip-list>

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
@@ -1,7 +1,15 @@
 <mat-chip-list aria-label="Labels">
   <ng-container *ngFor="let label of labels">
     <mat-chip *ngIf="!labelSet?.has(label.name)" [ngStyle]="labelService.setLabelStyle(label.color)" selected>
-      <span class="label-text">{{ label.name }}</span>
+      <span
+        #tooltipRef="matTooltip"
+        class="label-text"
+        [matTooltip]="tooltipLabel"
+        (mouseenter)="onMouseEnter($event, label.name, tooltipRef)"
+        (mouseleave)="onMouseLeave()"
+      >
+        {{ label.name }}
+      </span>
     </mat-chip>
   </ng-container>
 </mat-chip-list>

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.html
@@ -1,13 +1,15 @@
 <mat-chip-list aria-label="Labels">
   <ng-container *ngFor="let label of labels">
-    <mat-chip *ngIf="!labelSet?.has(label.name)" [ngStyle]="labelService.setLabelStyle(label.color)" selected>
-      <span
-        #tooltipRef="matTooltip"
-        class="label-text"
-        [matTooltip]="tooltipLabel"
-        (mouseenter)="onMouseEnter($event, label.name, tooltipRef)"
-        (mouseleave)="onMouseLeave()"
-      >
+    <mat-chip
+      *ngIf="!labelSet?.has(label.name)"
+      [ngStyle]="labelService.setLabelStyle(label.color)"
+      #tooltipRef="matTooltip"
+      [matTooltip]="tooltipLabel"
+      (mouseenter)="onMouseEnter($event, label.name, tooltipRef)"
+      (mouseleave)="onMouseLeave()"
+      selected
+    >
+      <span class="label-text">
         {{ label.name }}
       </span>
     </mat-chip>

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
@@ -18,7 +18,8 @@ export class IssuePrCardLabelsComponent {
 
   onMouseEnter(event: MouseEvent, labelName: string, tooltip: MatTooltip) {
     const element = event.target as HTMLElement;
-    if (element.scrollWidth > element.clientWidth) {
+    const span = element.querySelector('.label-text') as HTMLElement;
+    if (span.scrollWidth > span.clientWidth) {
       this.tooltipLabel = labelName;
 
       setTimeout(() => {

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
 import { GithubLabel } from '../../../core/models/github/github-label.model';
 import { LabelService } from '../../../core/services/label.service';
-import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-issue-pr-card-labels',

--- a/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card-labels/issue-pr-card-labels.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { GithubLabel } from '../../../core/models/github/github-label.model';
 import { LabelService } from '../../../core/services/label.service';
+import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-issue-pr-card-labels',
@@ -10,5 +11,25 @@ import { LabelService } from '../../../core/services/label.service';
 export class IssuePrCardLabelsComponent {
   @Input() labels: GithubLabel[];
   @Input() labelSet: Set<string>;
+
+  tooltipLabel: string | null = null;
+
   constructor(public labelService: LabelService) {}
+
+  onMouseEnter(event: MouseEvent, labelName: string, tooltip: MatTooltip) {
+    const element = event.target as HTMLElement;
+    if (element.scrollWidth > element.clientWidth) {
+      this.tooltipLabel = labelName;
+
+      setTimeout(() => {
+        tooltip.show();
+      });
+    } else {
+      this.tooltipLabel = null;
+    }
+  }
+
+  onMouseLeave() {
+    this.tooltipLabel = null;
+  }
 }

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -10,6 +10,10 @@
       [repoHasMilestones]="!milestoneService.hasNoMilestones"
       (click)="viewMilestoneInBrowser($event)"
     ></app-issue-pr-card-milestone>
-    <app-issue-pr-card-labels [labels]="issue.githubLabels" [labelSet]="filter?.hiddenLabels"></app-issue-pr-card-labels>
+    <app-issue-pr-card-labels
+      style="flex: 1 1 auto; min-width: 0"
+      [labels]="issue.githubLabels"
+      [labelSet]="filter?.hiddenLabels"
+    ></app-issue-pr-card-labels>
   </mat-card-content>
 </mat-card>


### PR DESCRIPTION
### Summary:

Fixes #451 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Used `text-overflow: ellipsis` to ensure that the label name fits within the card
- Added a tooltip to display the full label name on hover

### Screenshots:
![image](https://github.com/user-attachments/assets/6a3dc8be-78bb-4281-ac05-184a36715a0c)


### Proposed Commit Message:

```
Prevent label overflow in card with ellipsis and tooltip

When issues or PRs have labels that are too long, the label may
overflow the issue-pr-card component.

Apply text ellipsis when labels exceed the available width and display
the full label name in a tooltip to ensure that labels stay within the 
card without overflowing.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
