### PR TITLE
Move parent class instead of select panel class

### DIFF
--- a/src/app/shared/filter-bar/filter-bar.component.css
+++ b/src/app/shared/filter-bar/filter-bar.component.css
@@ -54,3 +54,18 @@ ul {
     }
   } */
 }
+
+/*
+To fix issue: https://github.com/CATcher-org/WATcher/issues/462
+.cdk-overlay-pane is a parent class to the select panel 
+and we want to transform the panel to the right. If we directly
+translate the panel class itself, this parent class remains
+in the original position, clicking on the area covered by the parent class
+will not close the select panel. 
+
+So we are transforming the whole parent class instead.
+*/
+::ng-deep .cdk-overlay-pane {
+  transform: translateX(200px) !important;
+  transform-origin: left center !important;
+}


### PR DESCRIPTION
### Summary:

Fixes #462 

#### Type of change:
- ✨ New Feature/ Enhancement

### Changes Made:

- Move the select panel to the open to the right

### Screenshots:
<img width="433" alt="Screenshot 2025-04-14 at 12 50 50 PM" src="https://github.com/user-attachments/assets/1d607251-f3df-4642-984d-bc845e28acfb" />


### Proposed Commit Message:

```
Make dropdown panel of filter bar open to the right
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [X] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
