### PR TITLE
Move filter bar to the left

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,4 +1,0 @@
-.container {
-  /* padding: 8px 16px;
-  min-height: 87.9vh; */
-}

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,5 +1,4 @@
 .container {
-  padding: 8px 16px;
-  min-height: 87.9vh;
-  flex-grow: 1;
+  /* padding: 8px 16px;
+  min-height: 87.9vh; */
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -1,8 +1,14 @@
+* {
+  box-sizing: border-box;
+}
+
 .card-column {
-  margin: 8px;
-  height: 100%;
+  padding: 8px;
+  /* height: 77vh; */
   display: flex;
   flex-direction: column;
+
+  height: 100%;
 }
 
 .card {

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -1,13 +1,18 @@
-.issues-viewer {
+/* .issues-viewer {
   display: flex;
   flex-direction: column;
   height: 100%;
-}
+} */
 
 .issue-table {
   width: 25%;
   min-width: 200px;
   max-width: 400px;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
 }
 
 .dropdown-filters .mat-form-field {
@@ -48,4 +53,59 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
+  height: calc(100vh - 64px);
+}
+
+.drawer-container {
+  background-color: white;
+}
+
+.content-container {
+  display: flex;
+  height: 100%;
+
+  /* Due to some library issues (?), the `content` for the sidenav is supposed to be an additional 6px, but for some reason
+  the margin-left of the container is automatically set wrongly. */
+  margin-left: 6px;
+}
+
+.toggle-switch-container {
+  width: 10px;
+  /* background-color: red; */
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 8px;
+  margin-right: 8px;
+
+  cursor: pointer;
+
+  mat-icon {
+    transition: all 0.3s ease-in-out;
+  }
+}
+
+.left {
+  /* width: 220px; */
+  /* flex-shrink: 0; */
+  /* background-color: red; */
+}
+
+.right {
+  flex-grow: 1;
+  display: flex;
+  overflow-x: auto;
+  /* background-color: blue; */
+
+  height: 100%;
+
+  box-sizing: border-box;
+  padding: 0.5rem 1rem 0.5rem 0;
 }

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -92,12 +92,6 @@
   }
 }
 
-.left {
-  /* width: 220px; */
-  /* flex-shrink: 0; */
-  /* background-color: red; */
-}
-
 .right {
   flex-grow: 1;
   display: flex;

--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -4,19 +4,38 @@
   </div>
 
   <ng-template #elseBlock>
-    <app-filter-bar [views$]="views" style="flex: 0 0 auto"></app-filter-bar>
-
-    <div class="wrapper">
-      <app-card-view
-        *ngFor="let group of this.groupService.groups"
-        class="issue-table"
-        #card
-        [ngStyle]="{ display: card.isLoading || card.issueLength > 0 ? 'initial' : 'none' }"
-        [group]="group"
-        [headers]="this.displayedColumns"
-        (issueLengthChange)="this.groupService.updateHiddenGroups($event, group)"
-      ></app-card-view>
-      <app-hidden-groups [groups]="this.groupService.hiddenGroups"></app-hidden-groups>
+    <div class="container">
+      <mat-drawer-container class="drawer-container">
+        <mat-drawer #sidenav mode="side" opened>
+          <div class="left">
+            <app-filter-bar [views$]="views"></app-filter-bar>
+          </div>
+        </mat-drawer>
+        <mat-drawer-content>
+          <div class="content-container">
+            <div class="toggle-switch-container" (click)="sidenav.toggle()">
+              <mat-icon
+                [matTooltip]="sidenav.opened ? 'Hide filters' : 'Show filters'"
+                matTooltipPosition="right"
+                [style.transform]="sidenav.opened ? 'rotate(180deg)' : 'rotate(0deg)'"
+                >chevron_right</mat-icon
+              >
+            </div>
+            <div class="right">
+              <app-card-view
+                *ngFor="let group of this.groupService.groups"
+                class="issue-table"
+                #card
+                [ngStyle]="{ display: card.isLoading || card.issueLength > 0 ? 'initial' : 'none' }"
+                [group]="group"
+                [headers]="this.displayedColumns"
+                (issueLengthChange)="this.groupService.updateHiddenGroups($event, group)"
+              ></app-card-view>
+              <app-hidden-groups [groups]="this.groupService.hiddenGroups"></app-hidden-groups>
+            </div>
+          </div>
+        </mat-drawer-content>
+      </mat-drawer-container>
     </div>
   </ng-template>
 </div>

--- a/src/app/issues-viewer/issues-viewer.component.ts
+++ b/src/app/issues-viewer/issues-viewer.component.ts
@@ -39,6 +39,9 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
 
   views = new BehaviorSubject<QueryList<CardViewComponent>>(undefined);
 
+  /** Hide or show the filter bar */
+  showFilterBar = false;
+
   constructor(
     public viewService: ViewService,
     public githubService: GithubService,
@@ -100,5 +103,9 @@ export class IssuesViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     this.groupService.resetGroups();
     this.availableGroupsSubscription = this.groupingContextService.getGroups().subscribe((x) => (this.groupService.groups = x));
+  }
+
+  private toggleSidebar() {
+    this.showFilterBar = !this.showFilterBar;
   }
 }

--- a/src/app/shared/filter-bar/filter-bar.component.css
+++ b/src/app/shared/filter-bar/filter-bar.component.css
@@ -1,19 +1,16 @@
-.filters .mat-form-field {
-  margin: 8px;
-  font-size: 14px;
-  max-width: 20%;
-  width: 14%; /* depends on number of filters*/
-}
-
 ul {
   margin: 8px;
-  padding: 0;
+  padding: 8px;
   display: flex;
-  align-items: center;
   justify-content: space-between;
   list-style-type: none;
   position: relative;
   max-height: 80px;
+
+  flex-direction: column;
+
+  position: sticky;
+  top: 0;
 }
 
 .menu {
@@ -29,13 +26,17 @@ ul {
 }
 
 .filters {
-  width: 57%;
-  display: flex;
-  align-items: center;
-  flex: 1;
-  margin-right: 100px;
+  font-size: 14px;
+  flex-direction: column;
 
-  @media (max-width: 1400px) {
+  display: flex;
+  /* align-items: center; */
+  flex: 1;
+
+  position: sticky;
+  top: 0;
+
+  /* @media (max-width: 1400px) {
     display: none;
 
     &.is-open {
@@ -51,5 +52,5 @@ ul {
         margin: 8px;
       }
     }
-  }
+  } */
 }

--- a/src/app/shared/filter-bar/filter-bar.component.css
+++ b/src/app/shared/filter-bar/filter-bar.component.css
@@ -54,3 +54,18 @@ ul {
     }
   } */
 }
+
+/*
+To fix issue: https://github.com/CATcher-org/WATcher/issues/462
+.cdk-overlay-pane is a parent class to the select panel 
+and we want to transform the panel to the right. If we directly
+translate the panel class itself, this parent class remains
+in the original position, clicking on the area covered by the parent class
+will not close the select panel. 
+
+So we are transforming the whole parent class instead.
+*/
+::ng-deep .cdk-overlay-pane {
+  transform: translateX(200px) !important;
+  transform-origin: left center !important;
+}

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -10,7 +10,7 @@
     </mat-form-field>
   </li>
 
-  <li class="filters" [class.is-open]="isMenuOpen">
+  <li class="filters">
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Group by</mat-label>
       <mat-select
@@ -109,8 +109,5 @@
       </mat-select>
     </mat-form-field>
     <app-label-filter-bar></app-label-filter-bar>
-  </li>
-  <li class="menu" (click)="toggleMenu()">
-    <i class="material-icons">{{ isMenuOpen ? 'close' : 'menu' }}</i>
   </li>
 </ul>

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -29,9 +29,6 @@ export class FilterBarComponent implements OnInit, OnDestroy {
   filter: Filter = this.filtersService.defaultFilter;
 
   groupByEnum: typeof GroupBy = GroupBy;
-
-  isMenuOpen = false;
-
   statusOptions = StatusOptions;
   typeOptions = TypeOptions;
   sortOptions = SortOptions;
@@ -114,9 +111,5 @@ export class FilterBarComponent implements OnInit, OnDestroy {
       (err) => {},
       () => {}
     );
-  }
-
-  toggleMenu(): void {
-    this.isMenuOpen = !this.isMenuOpen;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,11 +17,11 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
-app-root {
+/* app-root {
   display: flex;
   flex-direction: column;
   height: 100vh;
-}
+} */
 
 /* Timeline comment style */
 .timeline-header {

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,12 +17,6 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
-/* app-root {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-} */
-
 /* Timeline comment style */
 .timeline-header {
   background-color: #f1f8ff;


### PR DESCRIPTION
### Summary:

Fixes #363 and #462 and #396

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Shifted the layout of the home page to include one fixed-width full-height container for the filter bar, and one horizontally scrollable container for the content
- Removed the old "Menu" button that appeared when the screen size was too small
- Move the select panel to the open to the right

### Screenshots:

https://github.com/user-attachments/assets/e6194814-7374-42da-b23c-dc6d0c3e3899


![image](https://github.com/user-attachments/assets/95560b43-70cc-486e-9549-e848e045bc78)

### Proposed Commit Message:

```
The current filter bar being at the top results in issues with
extensibility and usability. 

Let's move the bar to the left so it is in a consistent position and
easy for users to access at any time.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
