### PR TITLE
Target only filter-bar-panel to move to right

### DIFF
--- a/src/app/shared/filter-bar/filter-bar.component.css
+++ b/src/app/shared/filter-bar/filter-bar.component.css
@@ -65,7 +65,7 @@ will not close the select panel.
 
 So we are transforming the whole parent class instead.
 */
-::ng-deep .cdk-overlay-pane {
+::ng-deep .cdk-overlay-pane:has(.filter-bar-panel) {
   transform: translateX(200px) !important;
-  transform-origin: left center !important;
+  transform-origin: left !important;
 }

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -15,6 +15,7 @@
       <mat-label>Group by</mat-label>
       <mat-select
         [value]="this.groupingContextService.currGroupBy$ | async"
+        panelClass="filter-bar-panel"
         (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value)"
       >
         <mat-option *ngFor="let option of this.groupByEnum | keyvalue" [value]="option.value">{{ option.key }}</mat-option>
@@ -22,7 +23,12 @@
     </mat-form-field>
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Status</mat-label>
-      <mat-select [value]="this.filter.status" (selectionChange)="this.filtersService.updateFilters({ status: $event.value })" multiple>
+      <mat-select
+        [value]="this.filter.status"
+        panelClass="filter-bar-panel"
+        (selectionChange)="this.filtersService.updateFilters({ status: $event.value })"
+        multiple
+      >
         <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.OpenPullRequests">Open Pull Requests</mat-option>
         <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.MergedPullRequests">Merged Pull Requests</mat-option>
         <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.ClosedPullRequests">Closed Pull Request</mat-option>
@@ -32,7 +38,11 @@
     </mat-form-field>
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Type</mat-label>
-      <mat-select [value]="this.filter.type" (selectionChange)="this.filtersService.updateFilters({ type: $event.value })">
+      <mat-select
+        [value]="this.filter.type"
+        panelClass="filter-bar-panel"
+        (selectionChange)="this.filtersService.updateFilters({ type: $event.value })"
+      >
         <mat-option [value]="typeOptions.All">All</mat-option>
         <mat-option [value]="typeOptions.Issue">Issue</mat-option>
         <mat-option [value]="typeOptions.PullRequests">Pull Request</mat-option>
@@ -46,7 +56,7 @@
       class="filter-item"
     >
       <mat-label>Sort</mat-label>
-      <mat-select [value]="this.filter.sort.active">
+      <mat-select [value]="this.filter.sort.active" panelClass="filter-bar-panel">
         <mat-option [value]="sortOptions.Id">
           <span mat-sort-header="id">ID</span>
         </mat-option>
@@ -66,6 +76,7 @@
       <mat-select
         #milestoneSelectorRef
         [value]="this.filter.milestones"
+        panelClass="filter-bar-panel"
         (selectionChange)="this.filtersService.updateFilters({ milestones: $event.value })"
         [disabled]="this.milestoneService.hasNoMilestones"
         multiple
@@ -84,7 +95,11 @@
     </mat-form-field>
     <mat-form-field appearance="standard" class="filter-item">
       <mat-label>Items per page</mat-label>
-      <mat-select [value]="this.filter.itemsPerPage" (selectionChange)="this.filtersService.updateFilters({ itemsPerPage: $event.value })">
+      <mat-select
+        [value]="this.filter.itemsPerPage"
+        panelClass="filter-bar-panel"
+        (selectionChange)="this.filtersService.updateFilters({ itemsPerPage: $event.value })"
+      >
         <mat-option [value]="10">10</mat-option>
         <mat-option [value]="20">20</mat-option>
         <mat-option [value]="50">50</mat-option>
@@ -95,6 +110,7 @@
       <mat-select
         #assigneeSelectorRef
         [value]="this.filter.assignees"
+        panelClass="filter-bar-panel"
         (selectionChange)="this.filtersService.updateFilters({ assignees: $event.value })"
         [disabled]="this.assigneeService.hasNoAssignees"
         multiple

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.html
@@ -17,7 +17,7 @@
 
     <div *ngIf="!hasLabels(input.value)" class="no-labels">No Labels Found!</div>
 
-    <div class="scroll-container-wrapper">
+    <div class="scroll-container-wrapper filter-bar-panel">
       <div class="scroll-container">
         <div
           *ngFor="let label of this.allLabels"


### PR DESCRIPTION
### Summary:

Fixes #463 

#### Type of change:
- 🐛 Bug Fix

### Changes Made:

- Target only panels that has the class filter-bar-panel to style open to the right

### Screenshots:

https://github.com/user-attachments/assets/2f124269-9f73-44c7-9727-fe4082342ce3


### Proposed Commit Message:

```
Fix bug of all select panels opening to the right
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [X] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
