### PR TITLE
Show PR and issue count separately

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -130,6 +130,7 @@ div.column-header .mat-card-header {
   font-weight: 410;
   display: inline-flex;
   font-size: 14px;
+  flex-shrink: 0;
 }
 
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous {

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -26,6 +26,10 @@
   padding: 10px;
 }
 
+.count-margins {
+  margin-right: 4px;
+}
+
 :host ::ng-deep div.mat-card-header-text {
   margin: 2px;
 }
@@ -125,12 +129,21 @@ div.column-header .mat-card-header {
   background-color: rgb(222, 222, 222);
   border-radius: 3px;
   cursor: default;
-  padding: 6px;
+  padding: 6px 8px 3px 8px;
   color: rgb(0, 0, 0);
   font-weight: 410;
   display: inline-flex;
   font-size: 14px;
   flex-shrink: 0;
+  margin-top: 3px;
+}
+
+.assignee-container {
+  width: 100%;
+}
+
+.assignee-name {
+  text-overflow: ellipsis;
 }
 
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous {

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -43,7 +43,9 @@
         <mat-card-title>
           {{ assignee.login }}
         </mat-card-title>
-        <div class="row-count">{{ this.issues.count }}</div>
+        <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
+          {{ this.issues.issueCount }} | {{ this.issues.prCount }}
+        </div>
       </mat-card-header>
     </mat-card>
   </div>
@@ -56,7 +58,7 @@
         <mat-card-title>
           {{ milestone.title }}
         </mat-card-title>
-        <div class="row-count">{{ this.issues.count }}</div>
+        <div class="row-count">{{ this.issues.issueCount }} | {{ this.issues.prCount }}</div>
       </mat-card-header>
     </mat-card>
   </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -58,7 +58,9 @@
         <mat-card-title>
           {{ milestone.title }}
         </mat-card-title>
-        <div class="row-count">{{ this.issues.issueCount }} | {{ this.issues.prCount }}</div>
+        <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
+          {{ this.issues.issueCount }} | {{ this.issues.prCount }}
+        </div>
       </mat-card-header>
     </mat-card>
   </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -41,11 +41,19 @@
           }"
         ></div>
         <mat-card-title>
-          {{ assignee.login }}
+          <div class="assignee-container">
+            <div class="assignee-name">
+              {{ assignee.login }}
+            </div>
+            <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
+              <span class="octicon count-margins" octicon="issue-opened"></span>
+              <span class="count-margins">{{ this.issues.issueCount }}</span>
+              <span class="count-margins">|</span>
+              <span class="octicon count-margins" octicon="git-pull-request"></span>
+              <span>{{ this.issues.prCount }}</span>
+            </div>
+          </div>
         </mat-card-title>
-        <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
-          {{ this.issues.issueCount }} | {{ this.issues.prCount }}
-        </div>
       </mat-card-header>
     </mat-card>
   </div>
@@ -56,11 +64,19 @@
     <mat-card>
       <mat-card-header [ngStyle]="{ height: '40px' }">
         <mat-card-title>
-          {{ milestone.title }}
+          <div class="assignee-container">
+            <div class="assignee-name">
+              {{ milestone.title }}
+            </div>
+            <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
+              <span class="octicon count-margins" octicon="issue-opened"></span>
+              <span class="count-margins">{{ this.issues.issueCount }}</span>
+              <span class="count-margins">|</span>
+              <span class="octicon count-margins" octicon="git-pull-request"></span>
+              <span>{{ this.issues.prCount }}</span>
+            </div>
+          </div>
         </mat-card-title>
-        <div class="row-count" matTooltip="Issue | Pull Requests" matTooltipPosition="above">
-          {{ this.issues.issueCount }} | {{ this.issues.prCount }}
-        </div>
       </mat-card-header>
     </mat-card>
   </div>

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -84,7 +84,6 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
       this.pageSize = filter.itemsPerPage;
       this.paginator._changePageSize(this.pageSize);
     });
-    console.log(this.issues);
   }
 
   ngAfterViewInit(): void {

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -84,6 +84,7 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
       this.pageSize = filter.itemsPerPage;
       this.paginator._changePageSize(this.pageSize);
     });
+    console.log(this.issues);
   }
 
   ngAfterViewInit(): void {

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -19,6 +19,8 @@ import { applySearchFilter } from './search-filter';
 
 export class IssuesDataTable extends DataSource<Issue> implements FilterableSource {
   public count = 0;
+  public issueCount = 100;
+  public prCount = 100;
   private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
@@ -96,6 +98,9 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
           data = applyDropdownFilter(this.filter, data, !this.milestoneService.hasNoMilestones, !this.assigneeService.hasNoAssignees);
 
           data = applySearchFilter(this.filter.title, this.displayedColumn, this.issueService, data);
+          console.log(data);
+          this.issueCount = data.filter((issue) => issue.issueOrPr != 'PullRequest').length;
+          this.prCount = data.filter((issue) => issue.issueOrPr == 'PullRequest').length;
           this.count = data.length;
 
           data = applySort(this.filter.sort, data);

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -99,8 +99,8 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
 
           data = applySearchFilter(this.filter.title, this.displayedColumn, this.issueService, data);
           console.log(data);
-          this.issueCount = data.filter((issue) => issue.issueOrPr != 'PullRequest').length;
-          this.prCount = data.filter((issue) => issue.issueOrPr == 'PullRequest').length;
+          this.issueCount = data.filter((issue) => issue.issueOrPr !== 'PullRequest').length;
+          this.prCount = data.filter((issue) => issue.issueOrPr === 'PullRequest').length;
           this.count = data.length;
 
           data = applySort(this.filter.sort, data);


### PR DESCRIPTION
### Summary:

Fixes #442

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Split the count by issues and PRs this works for both groupby assignees and milestones.

### Screenshots:

![image](https://github.com/user-attachments/assets/d4db5351-0ee5-4b1e-841f-c1676aab9024)
![image](https://github.com/user-attachments/assets/ac3d80e8-6eec-46ac-9690-0683f66b3b60)
![image](https://github.com/user-attachments/assets/49d8fddc-e93b-4c12-b5c5-bc5fb9df28dd)

### Proposed Commit Message:

```
Add a new feature to separate the count of pr and issues

Separating the count allows users to get information faster, as they
will be able to see if someone has too many / lack of issues
and prs.

Let's separate the count and include an icon to distinguish the
different counts.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to an issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
