### PR TITLE
Add "deselect all" and "select all" options to Assignee filter

### DIFF
--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -229,7 +229,6 @@ export class FiltersService {
   }
 
   updateFilters(newFilters: Partial<Filter>): void {
-    console.log('Update filters called with, ', newFilters);
     const nextDropdownFilter: Filter = {
       ...this.filter$.value,
       ...newFilters

--- a/src/app/core/services/filters.service.ts
+++ b/src/app/core/services/filters.service.ts
@@ -229,6 +229,7 @@ export class FiltersService {
   }
 
   updateFilters(newFilters: Partial<Filter>): void {
+    console.log('Update filters called with, ', newFilters);
     const nextDropdownFilter: Filter = {
       ...this.filter$.value,
       ...newFilters

--- a/src/app/shared/filter-bar/filter-bar.component.css
+++ b/src/app/shared/filter-bar/filter-bar.component.css
@@ -69,3 +69,26 @@ So we are transforming the whole parent class instead.
   transform: translateX(200px) !important;
   transform-origin: left center !important;
 }
+
+/* 
+Hides the checkbox when we have buttons in `multiselects`.
+*/
+::ng-deep .dropdown-action {
+  pointer-events: none;
+  mat-pseudo-checkbox {
+    display: none;
+  }
+
+  .mat-ripple {
+    display: none;
+  }
+
+  button {
+    pointer-events: auto;
+  }
+}
+
+/**
+Prevents the ripple effect from showing when we click on the dropdown action button.
+*/
+/* ::ng-deep .dropdown-action> */

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -102,6 +102,16 @@
         <mat-select-trigger *ngIf="this.assigneeService.hasNoAssignees">
           <span>No Assignees</span>
         </mat-select-trigger>
+
+        <mat-option class="dropdown-action">
+          <button *ngIf="this.filter.assignees.length != 0" mat-button type="button" (click)="onDeselectAllClicked($event)">
+            Deselect All
+          </button>
+          <button *ngIf="this.filter.assignees.length == 0" mat-button type="button" (click)="onSelectAllClicked($event)">
+            Select All
+          </button>
+        </mat-option>
+
         <mat-option *ngFor="let assignee of this.assigneeService.assignees" [value]="assignee.login">
           {{ assignee.login }}
         </mat-option>

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -104,10 +104,10 @@
         </mat-select-trigger>
 
         <mat-option class="dropdown-action">
-          <button *ngIf="this.filter.assignees.length != 0" mat-button type="button" (click)="onDeselectAllClicked($event)">
+          <button *ngIf="this.filter.assignees.length != 0" mat-button type="button" (click)="onDeselectAllAssigneesClicked($event)">
             Deselect All
           </button>
-          <button *ngIf="this.filter.assignees.length == 0" mat-button type="button" (click)="onSelectAllClicked($event)">
+          <button *ngIf="this.filter.assignees.length == 0" mat-button type="button" (click)="onSelectAllAssigneesClicked($event)">
             Select All
           </button>
         </mat-option>

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -89,6 +89,22 @@ export class FilterBarComponent implements OnInit, OnDestroy {
     return this.filter.type === this.typeOptions.PullRequests || this.filter.type === this.typeOptions.All;
   }
 
+  onDeselectAllClicked(event: Event) {
+    event.stopPropagation(); // required, if not the (selectionChange) event will be triggered
+
+    this.filtersService.updateFilters({
+      assignees: []
+    });
+  }
+
+  onSelectAllClicked(event: Event) {
+    event.stopPropagation(); // required, if not the (selectionChange) event will be triggered
+
+    this.filtersService.updateFilters({
+      assignees: this.assigneeService.assignees.map((assignee) => assignee.login)
+    });
+  }
+
   /**
    * Fetch and initialize all information from repository to populate Issue Dashboard.
    * Re-called when repo has changed

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -89,7 +89,7 @@ export class FilterBarComponent implements OnInit, OnDestroy {
     return this.filter.type === this.typeOptions.PullRequests || this.filter.type === this.typeOptions.All;
   }
 
-  onDeselectAllClicked(event: Event) {
+  onDeselectAllAssigneesClicked(event: Event) {
     event.stopPropagation(); // required, if not the (selectionChange) event will be triggered
 
     this.filtersService.updateFilters({
@@ -97,11 +97,11 @@ export class FilterBarComponent implements OnInit, OnDestroy {
     });
   }
 
-  onSelectAllClicked(event: Event) {
+  onSelectAllAssigneesClicked(event: Event) {
     event.stopPropagation(); // required, if not the (selectionChange) event will be triggered
 
     this.filtersService.updateFilters({
-      assignees: this.assigneeService.assignees.map((assignee) => assignee.login)
+      assignees: [...this.assigneeService.assignees.map((assignee) => assignee.login), 'Unassigned']
     });
   }
 


### PR DESCRIPTION
### Summary:

Fixes #423 

#### Type of change:

(Delete where appropriate)

- ✨ New Feature/ Enhancement

### Changes Made:

- Add new methods to handle click events
- Add a new `mat-option` consisting of a contextual-dependent button for deselect / select

### Screenshots:

![Uploading chrome_iF2wIA2Y9y.gif…]()



### Proposed Commit Message:

```
Currently, it is tedious to deselect all the assignees when
we want to view only one assignee. Let's provide a deselect all
(and select all) button to reduce the number of clicks.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
