### PR TITLE
Fix: Escape key now properly closes active filter elements only

### DIFF
--- a/src/app/issues-viewer/issues-viewer.component.html
+++ b/src/app/issues-viewer/issues-viewer.component.html
@@ -8,7 +8,11 @@
       <mat-drawer-container class="drawer-container">
         <mat-drawer #sidenav mode="side" opened>
           <div class="left">
-            <app-filter-bar [views$]="views"></app-filter-bar>
+            <app-filter-bar
+              [views$]="views"
+              (escapePressed)="sidenav.close()"
+              >
+            </app-filter-bar>
           </div>
         </mat-drawer>
         <mat-drawer-content>

--- a/src/app/shared/filter-bar/filter-bar.component.html
+++ b/src/app/shared/filter-bar/filter-bar.component.html
@@ -1,129 +1,132 @@
-<ul>
-  <li>
-    <mat-form-field class="search-bar">
-      <input
-        matInput
-        value="{{ this.filtersService.filter$.value.title }}"
-        (keyup)="this.filtersService.updateFilters({ title: $event.target.value })"
-        placeholder="Search"
-      />
-    </mat-form-field>
-  </li>
+<div tabindex="0" (keydown.escape)="handleEscape($event)">
+  <ul>
+    <li>
+      <mat-form-field class="search-bar">
+        <input
+          #searchInputRef
+          matInput
+          value="{{ this.filtersService.filter$.value.title }}"
+          (keyup)="this.filtersService.updateFilters({ title: $event.target.value })"
+          placeholder="Search"
+        />
+      </mat-form-field>
+    </li>
 
-  <li class="filters">
-    <mat-form-field appearance="standard" class="filter-item">
-      <mat-label>Group by</mat-label>
-      <mat-select
-        [value]="this.groupingContextService.currGroupBy$ | async"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value)"
-      >
-        <mat-option *ngFor="let option of this.groupByEnum | keyvalue" [value]="option.value">{{ option.key }}</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="standard" class="filter-item">
-      <mat-label>Status</mat-label>
-      <mat-select
-        [value]="this.filter.status"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.filtersService.updateFilters({ status: $event.value })"
-        multiple
-      >
-        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.OpenPullRequests">Open Pull Requests</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.MergedPullRequests">Merged Pull Requests</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.ClosedPullRequests">Closed Pull Request</mat-option>
-        <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.OpenIssues">Open Issues</mat-option>
-        <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.ClosedIssues">Closed Issues</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="standard" class="filter-item">
-      <mat-label>Type</mat-label>
-      <mat-select
-        [value]="this.filter.type"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.filtersService.updateFilters({ type: $event.value })"
-      >
-        <mat-option [value]="typeOptions.All">All</mat-option>
-        <mat-option [value]="typeOptions.Issue">Issue</mat-option>
-        <mat-option [value]="typeOptions.PullRequests">Pull Request</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field
-      appearance="standard"
-      matSort
-      [matSortDisableClear]="true"
-      (matSortChange)="this.filtersService.updateFilters({ sort: $event })"
-      class="filter-item"
-    >
-      <mat-label>Sort</mat-label>
-      <mat-select [value]="this.filter.sort.active" panelClass="filter-bar-panel">
-        <mat-option [value]="sortOptions.Id">
-          <span mat-sort-header="id">ID</span>
-        </mat-option>
-        <mat-option [value]="sortOptions.Title">
-          <span mat-sort-header="title">Title</span>
-        </mat-option>
-        <mat-option [value]="sortOptions.Date">
-          <span mat-sort-header="date">Date Updated</span>
-        </mat-option>
-        <mat-option [value]="sortOptions.Status">
-          <span mat-sort-header="status">Status</span>
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="standard" class="filter-item">
-      <mat-label>Milestone</mat-label>
-      <mat-select
-        #milestoneSelectorRef
-        [value]="this.filter.milestones"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.filtersService.updateFilters({ milestones: $event.value })"
-        [disabled]="this.milestoneService.hasNoMilestones"
-        multiple
-      >
-        <mat-select-trigger *ngIf="this.milestoneService.hasNoMilestones">
-          <span>No Milestones</span>
-        </mat-select-trigger>
-        <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.title">
-          {{ milestone.title }}
-        </mat-option>
-        <mat-option *ngIf="isFilterIssue()" [value]="milestoneOptions.IssueWithoutMilestone">Issues without a milestone</mat-option>
-        <mat-option *ngIf="isFilterPullRequest()" [value]="milestoneOptions.PullRequestWithoutMilestone"
-          >PRs without a milestone</mat-option
+    <li class="filters">
+      <mat-form-field appearance="standard" class="filter-item">
+        <mat-label>Group by</mat-label>
+        <mat-select
+          [value]="this.groupingContextService.currGroupBy$ | async"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.groupingContextService.setCurrentGroupingType($event.value)"
         >
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="standard" class="filter-item">
-      <mat-label>Items per page</mat-label>
-      <mat-select
-        [value]="this.filter.itemsPerPage"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.filtersService.updateFilters({ itemsPerPage: $event.value })"
+          <mat-option *ngFor="let option of this.groupByEnum | keyvalue" [value]="option.value">{{ option.key }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="standard" class="filter-item">
+        <mat-label>Status</mat-label>
+        <mat-select
+          [value]="this.filter.status"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.filtersService.updateFilters({ status: $event.value })"
+          multiple
+        >
+          <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.OpenPullRequests">Open Pull Requests</mat-option>
+          <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.MergedPullRequests">Merged Pull Requests</mat-option>
+          <mat-option *ngIf="isFilterPullRequest()" [value]="statusOptions.ClosedPullRequests">Closed Pull Request</mat-option>
+          <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.OpenIssues">Open Issues</mat-option>
+          <mat-option *ngIf="isFilterIssue()" [value]="statusOptions.ClosedIssues">Closed Issues</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="standard" class="filter-item">
+        <mat-label>Type</mat-label>
+        <mat-select
+          [value]="this.filter.type"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.filtersService.updateFilters({ type: $event.value })"
+        >
+          <mat-option [value]="typeOptions.All">All</mat-option>
+          <mat-option [value]="typeOptions.Issue">Issue</mat-option>
+          <mat-option [value]="typeOptions.PullRequests">Pull Request</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field
+        appearance="standard"
+        matSort
+        [matSortDisableClear]="true"
+        (matSortChange)="this.filtersService.updateFilters({ sort: $event })"
+        class="filter-item"
       >
-        <mat-option [value]="10">10</mat-option>
-        <mat-option [value]="20">20</mat-option>
-        <mat-option [value]="50">50</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="standard">
-      <mat-label>Assigned to</mat-label>
-      <mat-select
-        #assigneeSelectorRef
-        [value]="this.filter.assignees"
-        panelClass="filter-bar-panel"
-        (selectionChange)="this.filtersService.updateFilters({ assignees: $event.value })"
-        [disabled]="this.assigneeService.hasNoAssignees"
-        multiple
-      >
-        <mat-select-trigger *ngIf="this.assigneeService.hasNoAssignees">
-          <span>No Assignees</span>
-        </mat-select-trigger>
-        <mat-option *ngFor="let assignee of this.assigneeService.assignees" [value]="assignee.login">
-          {{ assignee.login }}
-        </mat-option>
-        <mat-option [value]="'Unassigned'">Unassigned</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <app-label-filter-bar></app-label-filter-bar>
-  </li>
-</ul>
+        <mat-label>Sort</mat-label>
+        <mat-select [value]="this.filter.sort.active" panelClass="filter-bar-panel">
+          <mat-option [value]="sortOptions.Id">
+            <span mat-sort-header="id">ID</span>
+          </mat-option>
+          <mat-option [value]="sortOptions.Title">
+            <span mat-sort-header="title">Title</span>
+          </mat-option>
+          <mat-option [value]="sortOptions.Date">
+            <span mat-sort-header="date">Date Updated</span>
+          </mat-option>
+          <mat-option [value]="sortOptions.Status">
+            <span mat-sort-header="status">Status</span>
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="standard" class="filter-item">
+        <mat-label>Milestone</mat-label>
+        <mat-select
+          #milestoneSelectorRef
+          [value]="this.filter.milestones"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.filtersService.updateFilters({ milestones: $event.value })"
+          [disabled]="this.milestoneService.hasNoMilestones"
+          multiple
+        >
+          <mat-select-trigger *ngIf="this.milestoneService.hasNoMilestones">
+            <span>No Milestones</span>
+          </mat-select-trigger>
+          <mat-option *ngFor="let milestone of this.milestoneService.milestones" [value]="milestone.title">
+            {{ milestone.title }}
+          </mat-option>
+          <mat-option *ngIf="isFilterIssue()" [value]="milestoneOptions.IssueWithoutMilestone">Issues without a milestone</mat-option>
+          <mat-option *ngIf="isFilterPullRequest()" [value]="milestoneOptions.PullRequestWithoutMilestone"
+            >PRs without a milestone</mat-option
+          >
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="standard" class="filter-item">
+        <mat-label>Items per page</mat-label>
+        <mat-select
+          [value]="this.filter.itemsPerPage"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.filtersService.updateFilters({ itemsPerPage: $event.value })"
+        >
+          <mat-option [value]="10">10</mat-option>
+          <mat-option [value]="20">20</mat-option>
+          <mat-option [value]="50">50</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="standard">
+        <mat-label>Assigned to</mat-label>
+        <mat-select
+          #assigneeSelectorRef
+          [value]="this.filter.assignees"
+          panelClass="filter-bar-panel"
+          (selectionChange)="this.filtersService.updateFilters({ assignees: $event.value })"
+          [disabled]="this.assigneeService.hasNoAssignees"
+          multiple
+        >
+          <mat-select-trigger *ngIf="this.assigneeService.hasNoAssignees">
+            <span>No Assignees</span>
+          </mat-select-trigger>
+          <mat-option *ngFor="let assignee of this.assigneeService.assignees" [value]="assignee.login">
+            {{ assignee.login }}
+          </mat-option>
+          <mat-option [value]="'Unassigned'">Unassigned</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <app-label-filter-bar></app-label-filter-bar>
+    </li>
+  </ul>
+</div>

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -125,19 +125,24 @@ export class FilterBarComponent implements OnInit, OnDestroy {
    */
   @HostListener('keydown.escape', ['$event'])
   handleEscape(event: KeyboardEvent) {
+    let handled = false;
+
     const openDropdown = this.matSelects.find((select) => select.panelOpen);
+    
     if (openDropdown) {
-      event.preventDefault();
-      event.stopImmediatePropagation();
       openDropdown.close();
+      handled = true;
     } else if (this.searchInputRef && document.activeElement === this.searchInputRef.nativeElement) {
       this.searchInputRef.nativeElement.blur();
-      event.preventDefault();
-      event.stopImmediatePropagation();
+      handled = true;
     } else if (this.labelFilterBar && this.labelFilterBar.isOpen()) {
+      this.labelFilterBar.closeMenu();
+      handled = true;
+    }
+    
+    if (handled) {
       event.preventDefault();
       event.stopImmediatePropagation();
-      this.labelFilterBar.closeMenu();
     }
   }
 }

--- a/src/app/shared/filter-bar/filter-bar.component.ts
+++ b/src/app/shared/filter-bar/filter-bar.component.ts
@@ -1,4 +1,17 @@
-import { AfterViewInit, Component, HostListener, Input, OnDestroy, OnInit, QueryList, Type, ViewChild, ViewChildren } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  QueryList,
+  Type,
+  ViewChild,
+  ViewChildren
+} from '@angular/core';
 import { MatSelect } from '@angular/material/select';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { MilestoneOptions, SortOptions, StatusOptions, TypeOptions } from '../../core/constants/filter-options.constants';
@@ -10,7 +23,6 @@ import { MilestoneService } from '../../core/services/milestone.service';
 import { ViewService } from '../../core/services/view.service';
 import { FilterableComponent } from '../issue-tables/filterableTypes';
 import { LabelFilterBarComponent } from './label-filter-bar/label-filter-bar.component';
-import { EventEmitter, Output} from '@angular/core';
 
 /**
  * This component is abstracted out filterbar used by both detailed-viewer page
@@ -46,6 +58,8 @@ export class FilterBarComponent implements OnInit, OnDestroy {
   @ViewChildren(MatSelect) matSelects!: QueryList<MatSelect>;
 
   @ViewChild('searchInputRef') searchInputRef: any;
+
+  @Output() escapePressed = new EventEmitter<void>();
 
   constructor(
     public assigneeService: AssigneeService,
@@ -118,7 +132,6 @@ export class FilterBarComponent implements OnInit, OnDestroy {
     );
   }
 
-  @Output() escapePressed = new EventEmitter<void>();
   /**
    * Handles Escape key interactions within the filter bar:
    *
@@ -133,7 +146,7 @@ export class FilterBarComponent implements OnInit, OnDestroy {
    * - Accidental closure of unrelated components
    */
   @HostListener('document:keydown.escape', ['$event'])
-  handleEscape(event: KeyboardEvent) {    
+  handleEscape(event: KeyboardEvent) {
     const openDropdown = this.matSelects.find((select) => select.panelOpen);
 
     if (openDropdown) {

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -1,10 +1,10 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { MatMenuTrigger } from '@angular/material/menu';
 import { Observable, Subscription } from 'rxjs';
 import { SimpleLabel } from '../../../core/models/label.model';
 import { FiltersService } from '../../../core/services/filters.service';
 import { LabelService } from '../../../core/services/label.service';
 import { LoggingService } from '../../../core/services/logging.service';
-import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'app-label-filter-bar',

--- a/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
+++ b/src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.ts
@@ -4,6 +4,7 @@ import { SimpleLabel } from '../../../core/models/label.model';
 import { FiltersService } from '../../../core/services/filters.service';
 import { LabelService } from '../../../core/services/label.service';
 import { LoggingService } from '../../../core/services/logging.service';
+import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'app-label-filter-bar',
@@ -25,6 +26,8 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
   isDefault = true;
 
   labelSubscription: Subscription;
+
+  @ViewChild(MatMenuTrigger) menuTrigger: MatMenuTrigger;
 
   constructor(private labelService: LabelService, private logger: LoggingService, private filtersService: FiltersService) {}
 
@@ -136,5 +139,14 @@ export class LabelFilterBarComponent implements OnInit, AfterViewInit, OnDestroy
 
     this.isDefault = true;
     this.updateSelection();
+  }
+
+
+  isOpen(): boolean {
+    return this.menuTrigger?.menuOpen || false;
+  }
+
+  closeMenu(): void {
+    this.menuTrigger.closeMenu();
   }
 }


### PR DESCRIPTION
### Summary:

Fixes #469 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

Intercepted Escape key behaviour in `FilterBarComponent` to:
	•	Close any open `mat-select` dropdowns
	•	Blur the search input when focused
	•	Close the `LabelFilterBarComponent` if it is open
	•	Prevent unintended drawer collapse or window minimisation

### Screenshots:

![ScreenRecording2025-07-04at4 58 33PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/06d62d2e-bc56-479a-b6b1-2023add24c94)

### Proposed Commit Message:

```
Fix Escape key to close active elements before collapsing filter drawer

Previously, pressing Escape would minimise the entire window or collapse the filter drawer unintentionally.

This change intercepts the Escape key in FilterBarComponent to:
- Close any open mat-select dropdowns
- Blur the search input if focused
- Close the label filter menu if open

If no interactive element is active, the event bubbles up to trigger the drawer close as expected.

Improves keyboard accessibility and aligns with user expectations for modal/interactive behaviour.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- I have tested my changes thoroughly.

</details>
