### PR TITLE
Fix: Truncated Name in big repos

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -42,7 +42,7 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div class="assignee-name">
+            <div class="assignee-name" [matTooltip]="getAssigneeTooltip(assignee)" matTooltipPosition="above">
               {{ assignee.login }}
             </div>
             <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -145,4 +145,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   getPrTooltip(): string {
     return this.issues.prCount + ' Pull Requests';
   }
+
+  getAssigneeTooltip(assignee: any): string {
+    return assignee.login;
+  }
 }


### PR DESCRIPTION
### Summary:

Fixes #481 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Hovering over username will show a tooltip such that the user can view the full GitHub username, without needing to go to GitHub

### Screenshots:

![image](https://github.com/user-attachments/assets/7ddda38b-7508-4458-9938-d89653da25ce)

### Proposed Commit Message:

```
Add tooltip to display full GitHub username
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
