### PR TITLE
Add creation date display to issue/PR cards

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.css
@@ -46,6 +46,19 @@
   margin: 6px 0;
 }
 
+mat-card-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 8px 8px;
+  margin-top: 4px;
+  margin-right: -6px;
+}
+
+.date-created {
+  font-size: 10px;
+  color: #6c757d;
+}
+
 .content {
   width: 100%;
   display: flex;

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -30,4 +30,7 @@
       ></app-issue-pr-card-review-decision>
     </div>
   </mat-card-content>
+  <mat-card-footer>
+    <span class="date-created"> Created {{ issue.created_at | date: 'dd-MM-yy' }} </span>
+  </mat-card-footer>
 </mat-card>


### PR DESCRIPTION
### Summary:

Fixes #495 
Shows date that an issue/PR was created on the card

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

Added a footer to show the date of creation for an issue/PR

### Screenshots:

![Screenshot_14](https://github.com/user-attachments/assets/42cc0875-c029-4488-a07a-3fb54aaa8703)

### Proposed Commit Message:

```
Adds the creation date to the footer of each issue and pull
request card.

This improves the card's informativeness by providing users 
with immediate context on when the issue/PR was created, 
with minimal clutter.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
