### PR TITLE
Correct tooltip alignment for the assignee name

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -42,8 +42,8 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div>
-              <span class="assignee-name" [matTooltip]="getAssigneeTooltip(assignee)" matTooltipPosition="above">
+            <div class="assignee-name">
+              <span class="" [matTooltip]="getAssigneeTooltip(assignee)" matTooltipPosition="above">
                 {{ assignee.login }}
               </span>
             </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -42,8 +42,10 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div class="assignee-name" [matTooltip]="getAssigneeTooltip(assignee)" matTooltipPosition="above">
-              {{ assignee.login }}
+            <div>
+              <span class="assignee-name" [matTooltip]="getAssigneeTooltip(assignee)" matTooltipPosition="above">
+                {{ assignee.login }}
+              </span>
             </div>
             <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">
               <span class="octicon count-margins" octicon="issue-opened"></span>


### PR DESCRIPTION
### Summary:

Fixes #491 

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Ensured that the tooltip on the assignee name appears correctly above the name without affecting the header layout.
- Switched from using a div to a span for better inline alignment and tooltip positioning, while preserving the original design.

### Screenshots:

![image](https://github.com/user-attachments/assets/cbb328fc-d82e-494d-99fe-677493af11ff)

### Proposed Commit Message:

```
Correct tooltip alignment while preserving layout and proper truncation

The tooltip was applied to a div, causing it to anchor to the full container instead
of the assignee name — this resulted in the tooltip appearing awkwardly off-center.

This misalignment made the tooltip appear offset, reducing UX clarity.

Let's restructure the tooltip to a span, wrapped within a div encapsulating
the assignee name.

This allows the tooltip to align correctly above the assignee name
while preserving proper vertical alignment and ellipsis truncation
when text overflows.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- I have tested my changes thoroughly.

</details>
