### PR TITLE
Fix label filter bar test case error

### DIFF
--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -7,8 +7,8 @@ import { Filter, FiltersService } from '../../../../../src/app/core/services/fil
 import { LabelService } from '../../../../../src/app/core/services/label.service';
 import { LoggingService } from '../../../../../src/app/core/services/logging.service';
 import { LabelFilterBarComponent } from '../../../../../src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component';
-import { LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW, SEVERITY_SIMPLE_LABELS } from '../../../../constants/label.constants';
 import { DEFAULT_FILTER } from '../../../../constants/filter.constants';
+import { LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW, SEVERITY_SIMPLE_LABELS } from '../../../../constants/label.constants';
 
 describe('LabelFilterBarComponent', () => {
   let component: LabelFilterBarComponent;

--- a/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
+++ b/tests/app/shared/filter-bar/label-filter-bar/label-filter-bar.component.spec.ts
@@ -1,14 +1,14 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatSelectionList } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
 import { BehaviorSubject, of } from 'rxjs';
 import { SimpleLabel } from '../../../../../src/app/core/models/label.model';
-import { FiltersService } from '../../../../../src/app/core/services/filters.service';
+import { Filter, FiltersService } from '../../../../../src/app/core/services/filters.service';
 import { LabelService } from '../../../../../src/app/core/services/label.service';
 import { LoggingService } from '../../../../../src/app/core/services/logging.service';
 import { LabelFilterBarComponent } from '../../../../../src/app/shared/filter-bar/label-filter-bar/label-filter-bar.component';
 import { LABEL_NAME_SEVERITY_HIGH, LABEL_NAME_SEVERITY_LOW, SEVERITY_SIMPLE_LABELS } from '../../../../constants/label.constants';
+import { DEFAULT_FILTER } from '../../../../constants/filter.constants';
 
 describe('LabelFilterBarComponent', () => {
   let component: LabelFilterBarComponent;
@@ -21,7 +21,10 @@ describe('LabelFilterBarComponent', () => {
   beforeEach(async () => {
     labelServiceSpy = jasmine.createSpyObj('LabelService', ['connect', 'startPollLabels', 'fetchLabels']);
     loggingServiceSpy = jasmine.createSpyObj('LoggingService', ['info', 'debug']);
-    filtersServiceSpy = jasmine.createSpyObj('FiltersService', ['updateFilters', 'sanitizeLabels']);
+    filtersServiceSpy = jasmine.createSpyObj('FiltersService', ['updateFilters', 'sanitizeLabels'], {
+      defaultFilter: DEFAULT_FILTER
+    });
+    filtersServiceSpy.filter$ = new BehaviorSubject<Filter>(filtersServiceSpy.defaultFilter);
 
     TestBed.configureTestingModule({
       providers: [
@@ -52,12 +55,12 @@ describe('LabelFilterBarComponent', () => {
       filtersServiceSpy.sanitizeLabels.and.callThrough();
     });
 
-    // it('should update allLabels with latest emmitted value after ngAfterViewInit', fakeAsync(() => {
-    //   component.ngAfterViewInit();
-    //   tick();
-    //   labelsSubject.next(SEVERITY_SIMPLE_LABELS);
-    //   expect(component.allLabels).toEqual(SEVERITY_SIMPLE_LABELS);
-    // }));
+    it('should update allLabels with latest emmitted value after ngAfterViewInit', fakeAsync(() => {
+      component.ngAfterViewInit();
+      tick();
+      labelsSubject.next(SEVERITY_SIMPLE_LABELS);
+      expect(component.allLabels).toEqual(SEVERITY_SIMPLE_LABELS);
+    }));
   });
 
   describe('hide(label)', () => {


### PR DESCRIPTION
### Summary:

Fixes #305 

#### Type of change:

- 🐛 Bug Fix
- 🧪 Tests Update


### Changes Made:

Fix `ngAfterViewInit` failure due to incomplete initialisation of `filterServiceSpy`.

Included a `defaultFilter` property stub and assigned `filterServiceSpy.filter$` the same way as the actual code.

### Screenshots:

#### Before:

**When test case is commented out:**

![image](https://github.com/user-attachments/assets/3673b934-f5fd-4552-b8fe-9193d3dc7841)
![image](https://github.com/user-attachments/assets/11369751-e3fc-48fd-923b-542deac39ed9)

**When test case is uncommented:**

![image](https://github.com/user-attachments/assets/6eca7e81-4557-4dce-899e-1f7662b947d8)
![image](https://github.com/user-attachments/assets/f2633ac5-db78-4c35-875c-f9a0610925e2)


#### After:
![image](https://github.com/user-attachments/assets/177f209d-56d0-4bbe-9c7f-23398533fab9)
![image](https://github.com/user-attachments/assets/15899f8c-8de3-4b3e-bdf5-53f7cfba153f)


### Proposed Commit Message:

```
Fix label filter bar test case error.

Add a `defaultFilter` stub to filterServiceSpy to solve the problem of
reading values from undefined properties.

Now all test cases in `label-filter-bar.component.spec.ts` should be
able to pass.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
