### PR TITLE
Improve Apollo error handling and log missing repositories gracefully

### DIFF
--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -1,7 +1,9 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { ApolloError } from '@apollo/client/core';
 import { RequestError } from '@octokit/request-error';
+import { GraphQLError } from 'graphql';
 import { FormErrorComponent } from '../../shared/error-toasters/form-error/form-error.component';
 import { GeneralMessageErrorComponent } from '../../shared/error-toasters/general-message-error/general-message-error.component';
 import { LoggingService } from './logging.service';
@@ -10,14 +12,52 @@ export const ERRORCODE_NOT_FOUND = 404;
 
 const FILTERABLE = ['node_modules'];
 
+interface RejectionErrorWrapper {
+  rejection?: unknown;
+}
+
+function hasRejection(error: unknown): error is RejectionErrorWrapper {
+  return typeof error === 'object' && error !== null && 'rejection' in error;
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class ErrorHandlingService implements ErrorHandler {
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 
-  handleError(error: HttpErrorResponse | Error | RequestError, actionCallback?: () => void) {
+  handleError(
+    error: HttpErrorResponse | Error | RequestError | ApolloError | RejectionErrorWrapper,
+    actionCallback?: () => void
+  ): void {
+    if (hasRejection(error)) {
+      error = error.rejection;
+    }
+
+    if (error instanceof ApolloError) {
+      if (error.graphQLErrors?.length) {
+        error.graphQLErrors.forEach((gqlError: GraphQLError) => {
+          const isRateLimit = gqlError.message.toLowerCase().includes('rate limit');
+          const message = isRateLimit
+            ? 'GitHub API rate limit exceeded. Please try again later.'
+            : gqlError.message;
+
+          this.logger.error(`[GraphQL error]: ${gqlError.message}`);
+
+          this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
+            data: { message },
+          });
+        });
+      } else if (error.networkError) {
+        this.handleHttpError(error.networkError as HttpErrorResponse, actionCallback);
+      } else {
+        this.handleGeneralError(error.message);
+      }
+      return;
+    }
+
     this.logger.error(error);
+
     if (error instanceof Error) {
       this.logger.debug('ErrorHandlingService: ', this.cleanStack(error.stack));
     }
@@ -26,7 +66,7 @@ export class ErrorHandlingService implements ErrorHandler {
     } else if (error.constructor.name === 'RequestError') {
       this.handleHttpError(error as RequestError, actionCallback);
     } else {
-      this.handleGeneralError(error.message || JSON.stringify(error));
+      this.handleGeneralError((error as Error).message || JSON.stringify(error));
     }
   }
 


### PR DESCRIPTION
### Summary:

Fixes #457 

#### Type of change:
- 🐛 Bug Fix

### Changes Made:

- Added robust global error handling for Apollo GraphQL errors, including handling rate-limit API errors gracefully.
- Enhanced error handler to unwrap promise rejections and handle ApolloError properly with user-friendly snack bars.
- Improved logging for missing repository data in GraphQL responses.
- Refactored error handling service to maintain TypeScript safety while avoiding uncaught promise errors.

### Screenshots:

<img width="746" height="113" alt="image" src="https://github.com/user-attachments/assets/69ad3734-002e-4d48-9742-eeb3fa49684a" />

![ScreenRecording2025-07-15at10 36 47PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7dd8b736-d4b3-4366-8fe9-0aa3fde9477d)

### Proposed Commit Message:

```
Improve Apollo error handling and log missing repositories gracefully

Previously, uncaught ApolloErrors — especially those triggered by exceeding
the GitHub API rate limit — surfaced as unhandled promise rejections.

This caused confusing, bloated error stacks in the console and toast messages,
detracting from the user experience and masking the root issue.

Let’s unwrap promise rejections at the top level and explicitly detect Apollo errors.
By inspecting graphQLErrors and networkError, we can now display
clear, user-friendly messages when rate limits are hit or data is unavailable.

Additionally, GraphQL responses sometimes lacked repository fields,
often due to upstream errors or permission issues.

The previous implementation assumed response.body.data.repository would exist,
causing runtime crashes or broken logic when it didn’t.

Let’s add guards and structured logging to flag when repositories are missing,
including relevant operationName context to help with debugging.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
