### PR TITLE
Enhancement: fix issue card sizing when filtering

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -9,10 +9,13 @@
   flex-direction: column;
 
   height: 100%;
+  width: 200px;
 }
 
 .card {
   margin: 8px 0px 8px 0px;
+  height: 100px;
+  width: 100%;
 }
 
 .mat-card-title {

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -9,7 +9,7 @@
   flex-direction: column;
 
   height: 100%;
-  width: 200px;
+  width: 100%;
 }
 
 .card {

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -34,7 +34,7 @@
       <mat-card-header [ngStyle]="{ height: '40px' }">
         <div
           mat-card-avatar
-          *ngIf="assignee"
+          *ngIf="assignee && assignee.login !== 'Unassigned'"
           [ngStyle]="{
             background: 'url(' + assignee.avatar_url + ')',
             'background-size': '40px'

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -5,9 +5,10 @@
 } */
 
 .issue-table {
-  width: 200px;
-  /*min-width: 200px;
-  max-width: 400px;*/
+  width: 300px;
+  min-width: 300px;
+  max-width: 300px;
+  flex: 0 0 300px;
 }
 
 .container {

--- a/src/app/issues-viewer/issues-viewer.component.css
+++ b/src/app/issues-viewer/issues-viewer.component.css
@@ -5,9 +5,9 @@
 } */
 
 .issue-table {
-  width: 25%;
-  min-width: 200px;
-  max-width: 400px;
+  width: 200px;
+  /*min-width: 200px;
+  max-width: 400px;*/
 }
 
 .container {


### PR DESCRIPTION
### Summary:

Fixes #484 

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Made issue cards have a consistent sizing by enforcing a fixed width (300px) (Other scale units would break the margin and padding consistency between issue-tables).
- Made its child elements stretch to 100% width.

### Screenshots:

https://github.com/user-attachments/assets/421220a4-9b3c-49d1-a3b4-d2aafa69fd19

### Proposed Commit Message:

```
Fix issue card sizing

The issue cards have inconsistent sizes during filtering.

The lack of size consistency does not look very good
to the user viewing a huge number of issues.

Let's,
* fix the width of the parent issue-table.
* make the issue cards cover 100% of the parent's width.

This should give more control over the desired 
column width for each issue-table and improve
size consistency for better visual appeal.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
