### PR TITLE
Fix: Handle deleted user login error when loading issues

### DIFF
--- a/src/app/core/models/github/github-graphql.issue-or-pr.ts
+++ b/src/app/core/models/github/github-graphql.issue-or-pr.ts
@@ -17,7 +17,7 @@ export class GithubGraphqlIssueOrPr extends GithubIssue {
         state: model.state,
         stateReason: null,
         user: {
-          login: model.author.login
+          login: model.author?.login || 'ghost'
         },
         assignees: flattenEdges(model.assignees.edges),
         labels: flattenEdges(model.labels.edges),
@@ -40,7 +40,7 @@ export class GithubGraphqlIssueOrPr extends GithubIssue {
         state: model.state,
         stateReason: model.stateReason,
         user: {
-          login: model.author.login
+          login: model.author?.login || 'ghost'
         },
         assignees: flattenEdges(model.assignees.edges),
         labels: flattenEdges(model.labels.edges),

--- a/src/app/core/models/github/github-graphql.issue.ts
+++ b/src/app/core/models/github/github-graphql.issue.ts
@@ -15,7 +15,7 @@ export class GithubGraphqlIssue extends GithubIssue {
       state: issue.state,
       stateReason: issue.stateReason,
       user: {
-        login: issue.author.login
+        login: issue.author?.login || 'ghost'
       },
       assignees: flattenEdges(issue.assignees.edges),
       labels: flattenEdges(issue.labels.edges),


### PR DESCRIPTION
### Summary:

Fixes https://github.com/CATcher-org/WATcher/issues/479
Removes the error "Cannot read properties of null (reading 'login')

#### Type of change:

- 🐛 Bug Fix

### Changes Made:

- Added null check to default a deleted user to 'ghost', which is a placeholder name for deleted GitHub accounts (https://github.com/ghost)

### Screenshots:d

### Proposed Commit Message:

```
Fix: Handle deleted user login error when loading issues

The error "Cannot read properties of null (reading 'login') is caused
by loading repositories containing issues created by deleted GitHub 
users.

This change adds a fallback to 'ghost', the placeholder for deleted GitHub 
accounts, to prevent the error from showing up during runtime.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [ ] I have tested my changes thoroughly.
- [ ] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [ ] I have added or modified code comments to improve code readability where necessary.
- [ ] I have updated the project's documentation as necessary.

</details>
