### PR TITLE
Add unit tests for issues and PRs

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -95,7 +95,7 @@ export class Issue {
     this.state = githubIssue.state;
     this.stateReason = githubIssue.stateReason;
     this.issueOrPr = githubIssue.issueOrPr;
-    this.author = githubIssue.user.login;
+    this.author = githubIssue.user?.login || 'ghost';
     // this.githubIssue = githubIssue;
     this.isDraft = githubIssue.isDraft;
     this.reviewDecision = githubIssue.reviewDecision;

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -67,7 +67,7 @@ export class Issue {
    * Processes and cleans a raw issue description obtained from user input.
    */
   static updateDescription(description: string): string {
-    const defaultString = 'No details provided by bug reporter.';
+    const defaultString = '';
     return Issue.orDefaultString(Issue.formatText(description), defaultString);
   }
 

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -112,7 +112,7 @@ export class Issue {
     this.reviews = githubIssue.reviews?.map((review) => new PullrequestReview(review));
   }
 
-  public static createPhaseBugReportingIssue(githubIssue: GithubIssue): Issue {
+  public static createFromGithubIssue(githubIssue: GithubIssue): Issue {
     return new Issue(githubIssue);
   }
 

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -197,7 +197,7 @@ export class IssueService {
   private createIssueModel(githubIssue: GithubIssue): Issue {
     switch (this.viewService.currentView) {
       case View.issuesViewer:
-        return Issue.createPhaseBugReportingIssue(githubIssue);
+        return Issue.createFromGithubIssue(githubIssue);
       default:
         return;
     }

--- a/tests/app/shared/issue-tables/issue-paginator.spec.ts
+++ b/tests/app/shared/issue-tables/issue-paginator.spec.ts
@@ -12,10 +12,10 @@ describe('issue-paginator', () => {
   describe('paginateData()', () => {
     let dataSet_7: Issue[];
     let paginator: MatPaginator;
-    const mediumSeverityIssueWithResponse: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-    const mediumSeverityIssueWithAssigneee: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
-    const lowSeverityFeatureFlawIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY);
-    const highSeverityDocumentationBugIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY);
+    const mediumSeverityIssueWithResponse: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+    const mediumSeverityIssueWithAssigneee: Issue = Issue.createFromGithubIssue(ISSUE_WITH_ASSIGNEES);
+    const lowSeverityFeatureFlawIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY);
+    const highSeverityDocumentationBugIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY);
 
     beforeEach(() => {
       dataSet_7 = [

--- a/tests/app/shared/issue-tables/issue-sorter.spec.ts
+++ b/tests/app/shared/issue-tables/issue-sorter.spec.ts
@@ -10,12 +10,12 @@ import {
 
 describe('issuer-sorter', () => {
   describe('applySort()', () => {
-    const dummyIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-    const otherDummyIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
+    const dummyIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+    const otherDummyIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_ASSIGNEES);
     const issuesList: Issue[] = [dummyIssue, otherDummyIssue];
 
-    const issueUpdatedEarlier: Issue = Issue.createPhaseBugReportingIssue(ISSUE_UPDATED_EARLIER);
-    const issueUpdatedLater: Issue = Issue.createPhaseBugReportingIssue(ISSUE_UPDATED_LATER);
+    const issueUpdatedEarlier: Issue = Issue.createFromGithubIssue(ISSUE_UPDATED_EARLIER);
+    const issueUpdatedLater: Issue = Issue.createFromGithubIssue(ISSUE_UPDATED_LATER);
     const issuesWithDifferentUpdatedDate: Issue[] = [issueUpdatedEarlier, issueUpdatedLater];
 
     const matSort: MatSort = new MatSort();

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -14,10 +14,10 @@ import { GITHUB_LABEL_FEATURE_FLAW } from '../../../constants/githublabel.consta
 describe('search-filter', () => {
   describe('applySearchFilter()', () => {
     let searchKey: string;
-    const mediumSeverityIssueWithResponse: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-    const mediumSeverityIssueWithAssigneee: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
-    const lowSeverityFeatureFlawIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY);
-    const highSeverityDocumentationBugIssue: Issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY);
+    const mediumSeverityIssueWithResponse: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+    const mediumSeverityIssueWithAssigneee: Issue = Issue.createFromGithubIssue(ISSUE_WITH_ASSIGNEES);
+    const lowSeverityFeatureFlawIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY);
+    const highSeverityDocumentationBugIssue: Issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY);
 
     const issuesList: Issue[] = [
       mediumSeverityIssueWithResponse,

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -198,6 +198,26 @@ export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
   isDraft: false
 });
 
+export const ISSUE_WITH_MOCK_DATA = new GithubIssue({
+  id: '987654321',
+  number: 201,
+  assignees: [],
+  body: 'This is a mock issue description',
+  created_at: '2025-01-10T09:00:00Z',
+  updated_at: '2025-01-11T10:30:00Z',
+  closed_at: '',
+  labels: [GITHUB_LABEL_TEAM_LABEL],
+  state: IssueState.Open,
+  stateReason: null,
+  title: 'Bug report example',
+  url: 'https://github.com/CATcher-org/WATcher-test/issues/201',
+  user: { login: 'bugReporter' },
+  milestone: MILESTONE_ONE,
+  comments: [],
+  issueOrPr: 'Issue',
+  isDraft: false
+});
+
 export const generateIssueWithRandomData: () => GithubIssue = () => {
   const created_and_updated_date: string = randomISODate();
   const issueNumber: number = randomIssueNumber();

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -29,7 +29,7 @@ const randomISODate: (startDate?: Date, endDate?: Date) => string = (
   return new Date(startDate.getTime() + Math.random() * (startDate.getTime() - endDate.getTime())).toISOString();
 };
 
-const USER_ANUBHAV_DETAILS = {
+export const USER_ANUBHAV_DETAILS = {
   login: USER_ANUBHAV.loginId
 };
 

--- a/tests/constants/githubpullrequest.constants.ts
+++ b/tests/constants/githubpullrequest.constants.ts
@@ -1,0 +1,67 @@
+import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
+import { IssueState } from '../../graphql/graphql-types';
+import { ReviewDecision } from '../../src/app/core/models/issue.model';
+import { PullrequestReviewState } from '../../src/app/core/models/pullrequest-review.model';
+import { USER_ANUBHAV, USER_JUNWEI } from './data.constants';
+import { MILESTONE_ONE } from './githubissue.constants';
+import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_FUNCTIONALITY_BUG } from './githublabel.constants';
+
+export const MOCK_PR_DATA = new GithubIssue({
+  id: '123456789',
+  number: 101,
+  assignees: [USER_ANUBHAV],
+  body: 'This is a mock PR description',
+  created_at: '2025-01-15T10:30:00Z',
+  updated_at: '2025-01-16T14:45:00Z',
+  closed_at: '',
+  labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_FUNCTIONALITY_BUG],
+  state: IssueState.Open,
+  stateReason: null,
+  title: 'Add new feature',
+  url: 'https://github.com/CATcher-org/WATcher-test/pulls/101',
+  user: { login: 'testuser' },
+  milestone: MILESTONE_ONE,
+  comments: [],
+  issueOrPr: 'PullRequest',
+  isDraft: false,
+  headRepository: 'testuser/WATcher-test',
+  reviewDecision: ReviewDecision.REVIEW_REQUIRED,
+  reviews: [
+    {
+      state: PullrequestReviewState.APPROVED,
+      author: USER_JUNWEI
+    }
+  ]
+});
+
+export const MOCK_DRAFT_PR_DATA = new GithubIssue({
+  ...MOCK_PR_DATA,
+  id: '123456790',
+  number: 102,
+  title: 'Draft feature',
+  url: 'https://github.com/CATcher-org/WATcher-test/pulls/102',
+  isDraft: true,
+  reviewDecision: null,
+  reviews: []
+});
+
+export const MOCK_MERGED_PR_DATA = new GithubIssue({
+  ...MOCK_PR_DATA,
+  id: '123456791',
+  number: 103,
+  title: 'Merged pull request',
+  url: 'https://github.com/CATcher-org/WATcher-test/pulls/103',
+  state: IssueState.Closed,
+  closed_at: '2025-01-20T16:00:00Z',
+  reviewDecision: ReviewDecision.APPROVED,
+  reviews: [
+    {
+      state: PullrequestReviewState.APPROVED,
+      author: USER_ANUBHAV
+    },
+    {
+      state: PullrequestReviewState.APPROVED,
+      author: USER_JUNWEI
+    }
+  ]
+});

--- a/tests/constants/githubpullrequest.constants.ts
+++ b/tests/constants/githubpullrequest.constants.ts
@@ -3,13 +3,13 @@ import { IssueState } from '../../graphql/graphql-types';
 import { ReviewDecision } from '../../src/app/core/models/issue.model';
 import { PullrequestReviewState } from '../../src/app/core/models/pullrequest-review.model';
 import { USER_ANUBHAV, USER_JUNWEI } from './data.constants';
-import { MILESTONE_ONE } from './githubissue.constants';
+import { MILESTONE_ONE, USER_ANUBHAV_DETAILS } from './githubissue.constants';
 import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_FUNCTIONALITY_BUG } from './githublabel.constants';
 
 export const MOCK_PR_DATA = new GithubIssue({
   id: '123456789',
   number: 101,
-  assignees: [USER_ANUBHAV],
+  assignees: [USER_ANUBHAV_DETAILS],
   body: 'This is a mock PR description',
   created_at: '2025-01-15T10:30:00Z',
   updated_at: '2025-01-16T14:45:00Z',

--- a/tests/constants/githubpullrequest.constants.ts
+++ b/tests/constants/githubpullrequest.constants.ts
@@ -24,7 +24,9 @@ export const MOCK_PR_DATA = new GithubIssue({
   comments: [],
   issueOrPr: 'PullRequest',
   isDraft: false,
-  headRepository: 'testuser/WATcher-test',
+  headRepository: {
+    nameWithOwner: 'testuser/WATcher-test'
+  },
   reviewDecision: ReviewDecision.REVIEW_REQUIRED,
   reviews: [
     {

--- a/tests/constants/githubpullrequest.constants.ts
+++ b/tests/constants/githubpullrequest.constants.ts
@@ -1,10 +1,10 @@
-import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
 import { IssueState } from '../../graphql/graphql-types';
+import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
 import { ReviewDecision } from '../../src/app/core/models/issue.model';
 import { PullrequestReviewState } from '../../src/app/core/models/pullrequest-review.model';
 import { USER_ANUBHAV, USER_JUNWEI } from './data.constants';
 import { MILESTONE_ONE, USER_ANUBHAV_DETAILS } from './githubissue.constants';
-import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_FUNCTIONALITY_BUG } from './githublabel.constants';
+import { GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_TEAM_LABEL } from './githublabel.constants';
 
 export const MOCK_PR_DATA = new GithubIssue({
   id: '123456789',

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -19,7 +19,7 @@ import {
 import { MOCK_DRAFT_PR_DATA, MOCK_MERGED_PR_DATA, MOCK_PR_DATA } from '../constants/githubpullrequest.constants';
 
 describe('Issue model class', () => {
-  describe('.createPhaseBugReportIssue(githubIssue)', () => {
+  describe('.createFromGithubIssue(githubIssue)', () => {
     it('should correctly create a issue that has an empty description', async () => {
       const issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
 
@@ -155,9 +155,12 @@ describe('GitHub issue description creation', () => {
 
   it('should create the correct GitHub issue description with hidden data', () => {
     const issue = Issue.createFromGithubIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-    const result = issue.createGithubIssueDescription();
+    const issueResult = issue.createGithubIssueDescription();
+    const pr = Issue.createFromGithubIssue(MOCK_PR_DATA);
+    const prResult = pr.createGithubIssueDescription();
 
-    expect(result).toEqual(`${issue.description}\n${issue.hiddenDataInDescription.toString()}`);
+    expect(prResult).toEqual(`${pr.description}\n${pr.hiddenDataInDescription.toString()}`);
+    expect(issueResult).toEqual(`${issue.description}\n${issue.hiddenDataInDescription.toString()}`);
   });
 
   it('should handle the issue with non-empty description correctly', () => {

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,9 +1,8 @@
 import * as moment from 'moment';
-import { Issue, ReviewDecision } from '../../src/app/core/models/issue.model';
 import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
+import { Issue, ReviewDecision } from '../../src/app/core/models/issue.model';
 import { Milestone } from '../../src/app/core/models/milestone.model';
 import { USER_ANUBHAV } from '../constants/data.constants';
-import { MOCK_PR_DATA, MOCK_DRAFT_PR_DATA, MOCK_MERGED_PR_DATA } from '../constants/githubpullrequest.constants';
 import {
   CLOSED_ISSUE_WITH_EMPTY_DESCRIPTION,
   ISSUE_WITHOUT_MILESTONE,
@@ -17,6 +16,7 @@ import {
   GITHUB_LABEL_TEAM_LABEL,
   GITHUB_LABEL_TUTORIAL_LABEL
 } from '../constants/githublabel.constants';
+import { MOCK_DRAFT_PR_DATA, MOCK_MERGED_PR_DATA, MOCK_PR_DATA } from '../constants/githubpullrequest.constants';
 
 describe('Issue model class', () => {
   describe('.createPhaseBugReportIssue(githubIssue)', () => {


### PR DESCRIPTION
### Summary:

Fixes #453 
Add test case coverage for issues and PRs, refactoring CATcher code into WATcher context during the process

#### Type of change:

- 🧪 Tests Update
- 🎨 Code Refactoring

### Changes Made:

- Created `githubpullrequest.constants.ts` with mock PR data for testing
- Update issue and add PR unit test cases
- Refactored tests from CATcher to WATcher context

### Proposed Commit Message:

```
Add unit tests for issues and PRs

Added comprehensive unit tests for issue and PR functionality.

Fixed null author test case by adding proper fallback to 'ghost' 
placeholder.

Refactored test suite from CATcher bug reporting context to WATcher
issue monitoring context, and renamed outdated functions.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
